### PR TITLE
Restructure rdist

### DIFF
--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -11,7 +11,6 @@ from ..inducing_variables import InducingPoints
 
 
 class S3(Manifold):
-
     # log of the uniform prior (negative log volume)
     log_uniform = (special.loggamma(2) - np.log(2) - 2 * np.log(np.pi))
 
@@ -70,8 +69,7 @@ class S3(Manifold):
     def lprior(self, g):
         return self.lprior_const * torch.ones(g.shape[:2])
 
-    def transform(self,
-                  x: Tensor,
+    def transform(self, x: Tensor,
                   batch_idxs: Optional[List[int]] = None) -> Tensor:
         mu = self.prms
         if batch_idxs is not None:

--- a/mgplvm/rdist.py
+++ b/mgplvm/rdist.py
@@ -9,7 +9,57 @@ from .utils import softplus, inv_softplus
 from typing import Optional
 
 
-class ReLie(Module):
+class Rdist(Module):
+    def __init__(self, manif, m, kmax):
+        super(Rdist, self).__init__()
+        self.manif = manif
+        self.d = manif.d
+        self.m = manif.m
+        self.kmax = kmax
+
+
+class ReLieBase(Rdist):
+    name = "ReLieBase"
+
+    def __init__(self, manif: Manifold, m: int, kmax: int = 5):
+        super(ReLieBase, self).__init__(manif, m, kmax)
+
+    def mvn(self, gamma, batch_idxs=None):
+        mu = torch.zeros(self.m, self.d).to(gamma.device)
+
+        if batch_idxs is not None:
+            mu = mu[batch_idxs]
+            gamma = gamma[batch_idxs]
+        return MultivariateNormal(mu, scale_tril=gamma)
+
+    def sample(self, gmu, gamma, size, batch_idxs=None, kmax=5):
+        """
+        generate samples and computes its log entropy
+        """
+        q = self.mvn(gamma, batch_idxs)
+        # sample a batch with dims: (n_mc x batch_size x d)
+        x = q.rsample(size)
+        gamma = self.prms
+        mu = torch.zeros(self.m).to(gamma.device)
+        if batch_idxs is not None:
+            gamma, mu = gamma[batch_idxs], mu[batch_idxs]
+        mu = mu[..., None]
+        lq = torch.stack([
+            self.manif.log_q(
+                Normal(mu, gamma[..., j, j][..., None]).log_prob,
+                x[..., j, None], 1, self.kmax).sum(dim=-1)
+            for j in range(self.d)
+        ]).sum(dim=0)
+
+        # transform x to group with dims (n_mc x m x d)
+        gtilde = self.manif.expmap(x)
+
+        # apply g_mu with dims: (n_mc x m x d)
+        g = self.manif.gmul(gmu[batch_idxs], gtilde)
+        return g, lq
+
+
+class ReLie(ReLieBase):
     name = "ReLie"
 
     def __init__(self,
@@ -31,15 +81,10 @@ class ReLie(Module):
         The diagonal approximation is useful for T^n as it saves an exponentially growing ReLie complexity
         The diagonal approximation only works for T^n and R^n
         '''
-        super(ReLie, self).__init__()
-        self.manif = manif
-        self.m = m
-        self.d = manif.d
-        self.kmax = kmax
-        d = self.d
+        super(ReLie, self).__init__(manif, m, kmax)
         self.diagonal = diagonal
 
-        gamma = torch.ones(m, d) * sigma
+        gamma = torch.ones(m, self.d) * sigma
         gamma = inv_softplus(gamma) if diagonal else torch.diag_embed(gamma)
         if gammas is not None:
             gamma[Tinds, ...] = torch.tensor(gammas,

--- a/mgplvm/rdist/__init__.py
+++ b/mgplvm/rdist/__init__.py
@@ -1,0 +1,2 @@
+from .common import Rdist
+from .relie import (ReLieBase, ReLie)

--- a/mgplvm/rdist/common.py
+++ b/mgplvm/rdist/common.py
@@ -1,0 +1,11 @@
+from ..base import Module
+from ..manifolds.base import Manifold
+
+
+class Rdist(Module):
+    def __init__(self, manif: Manifold, m: int, kmax: int):
+        super(Rdist, self).__init__()
+        self.manif = manif
+        self.d = manif.d
+        self.m = manif.m
+        self.kmax = kmax

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -3,19 +3,10 @@ from torch import nn, Tensor
 from torch.distributions.multivariate_normal import MultivariateNormal
 from torch.distributions.normal import Normal
 from torch.distributions import transform_to, constraints
-from .base import Module
-from .manifolds.base import Manifold
-from .utils import softplus, inv_softplus
+from ..utils import softplus, inv_softplus
+from ..manifolds.base import Manifold
+from .common import Rdist
 from typing import Optional
-
-
-class Rdist(Module):
-    def __init__(self, manif, m, kmax):
-        super(Rdist, self).__init__()
-        self.manif = manif
-        self.d = manif.d
-        self.m = manif.m
-        self.kmax = kmax
 
 
 class ReLieBase(Rdist):

--- a/tests/test_entropies.py
+++ b/tests/test_entropies.py
@@ -2,6 +2,7 @@ import mgplvm
 from mgplvm import rdist
 from mgplvm.utils import get_device
 from mgplvm.manifolds import So3, Torus, Euclid, S3
+from torch.distributions.multivariate_normal import MultivariateNormal
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
@@ -15,8 +16,7 @@ def test_euclid(kmax=5, savefig=False):
 
         manif = Euclid(m, d)
         sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-        q = mgplvm.rdist.MVN(m, d, sigma=torch.tensor(sigmas))()
-
+        q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
         x = q.rsample(torch.Size([200]))
         lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
         H = -lq.mean(dim=0).detach().numpy()
@@ -47,8 +47,7 @@ def test_torus(kmax=5, savefig=False):
 
         manif = Torus(m, d)
         sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-        q = mgplvm.rdist.MVN(m, d, sigma=torch.tensor(sigmas))()
-
+        q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
         x = q.rsample(torch.Size([200]))
         lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
         H = -lq.mean(dim=0).detach().numpy()
@@ -77,11 +76,9 @@ def test_torus(kmax=5, savefig=False):
 
 def test_so3(kmax=5, savefig=False):
     m = 100
-
     manif = So3(m)
     sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-    q = mgplvm.rdist.MVN(m, 3, sigma=torch.tensor(sigmas))()
-
+    q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
     x = q.rsample(torch.Size([200]))
     lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
     H = -lq.mean(dim=0).detach().numpy()
@@ -109,7 +106,7 @@ def test_s3(kmax=5, savefig=False):
 
     manif = S3(m)
     sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-    q = mgplvm.rdist.MVN(m, 3, sigma=torch.tensor(sigmas))()
+    q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
 
     x = q.rsample(torch.Size([200]))
     lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
@@ -131,3 +128,10 @@ def test_s3(kmax=5, savefig=False):
 
     assert np.amax(H - std) < Hmax  # adhere to upper bound
     assert np.abs(H[0] - Hgauss[0]) < std[0]  # adhere to lower bound
+
+
+if __name__ == "__main__":
+    test_euclid()
+    test_torus()
+    test_so3()
+    test_s3()

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -72,15 +72,15 @@ def test_kernels_run():
     sig0 = 1.5
     Y = gen.gen_data(ell=25, sig=1)
 
-    mydists = [Euclid.distance, Euclid.distance, Euclid.linear_distance]
-    mykernels = [QuadExp, Matern, Linear]
-    for i in [1]:
+    kernels = [
+        QuadExp(n, Euclid.distance),
+        Linear(n, Euclid.linear_distance, d),
+        # Matern(n, Euclid.distance)
+    ]
+    for kernel in kernels:
         # specify manifold, kernel and rdist
         manif = Euclid(m, d, initialization='random')
-
         lat_dist = mgplvm.rdist.ReLie(manif, m)
-        kernel = mykernels[i](n, mydists[i], nu=5 / 2)
-        print('\n\n', kernel.name)
         # generate model
         lik = likelihoods.Gaussian(n)
         lprior = lpriors.Uniform(manif)


### PR DESCRIPTION
This PR is to merged after merging #1 .

Here, I've separated out `rdist.py` into its own package in the folder `rdist`. 
I've also created a base class called `Rdist` inside `rdist/common.py` which will be the base class for all reference/latent distributions. In the future, we will add manifold-specific latent distributions (e.g., in `rdist/torus.py`). 

I've also created a new `ReLieBase` class which allows users to pass in their own `gmu` and `gamma`, which will make it much easier to do amortized inference.