### PR TITLE
Further restructuring of rdist

### DIFF
--- a/mgplvm/manifolds/base.py
+++ b/mgplvm/manifolds/base.py
@@ -6,11 +6,10 @@ from ..base import Module
 from typing import Optional
 
 
-class Manifold(Module, metaclass=abc.ABCMeta):
-    def __init__(self, d: int, initialization='random'):
+class Manifold(metaclass=abc.ABCMeta):
+    def __init__(self, d: int):
         """
         :param d: dimensionality of the manifold
-        initialization: specifies how the latent states are initialized
         """
         super().__init__()
         self.d = d
@@ -26,10 +25,6 @@ class Manifold(Module, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def inverse(self, x: Tensor) -> Tensor:
-        pass
-
-    @abc.abstractmethod
-    def transform(self, x: Tensor) -> Tensor:
         pass
 
     @staticmethod

--- a/mgplvm/manifolds/base.py
+++ b/mgplvm/manifolds/base.py
@@ -34,6 +34,11 @@ class Manifold(Module, metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
+    def parameterise(x: Tensor) -> Tensor:
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
     def expmap(x: Tensor) -> Tensor:
         pass
 

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -10,7 +10,7 @@ from sklearn import decomposition
 
 class Euclid(Manifold):
     def __init__(self, m: int, d: int):
-        super().__init__(d, initialization=initialization)
+        super().__init__(d)
         self.m = m
         self.d2 = d  # dimensionality of the group parameterization
 

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -9,28 +9,10 @@ from sklearn import decomposition
 
 
 class Euclid(Manifold):
-    def __init__(self,
-                 m: int,
-                 d: int,
-                 mu: Optional[np.ndarray] = None,
-                 Tinds: Optional[np.ndarray] = None,
-                 initialization: Optional[str] = 'random',
-                 Y: Optional[np.ndarray] = None):
-        '''
-        initialization: 'pca' or 'random' (default)
-        mu: optional initialization of the mean
-        Tinds: only set mean for these time points
-        '''
+    def __init__(self, m: int, d: int):
         super().__init__(d, initialization=initialization)
         self.m = m
         self.d2 = d  # dimensionality of the group parameterization
-
-        mudata = self.initialize(initialization, m, d, Y)
-        if mu is not None:
-            mudata[Tinds, ...] = torch.tensor(mu,
-                                              dtype=torch.get_default_dtype())
-
-        self.mu = nn.Parameter(data=mudata, requires_grad=True)
 
     @staticmethod
     def initialize(initialization, m, d, Y):
@@ -52,24 +34,10 @@ class Euclid(Manifold):
         z = torch.randn(n, self.d, n_z) if z is None else z
         return InducingPoints(n, self.d, n_z, z=z)
 
-    @property
-    def prms(self) -> Tensor:
-        return self.mu
-
-
-    def transform(self, x: Tensor,
-                  batch_idxs: Optional[List[int]] = None) -> Tensor:
-        mu = self.prms
-        if batch_idxs is not None:
-            mu = mu[batch_idxs]
-        return self.gmul(mu, x)
-
-
     def lprior(self, g):
         '''need empirical data here. g is (n_b x m x d)'''
         ps = -0.5 * torch.square(g) - 0.5 * np.log(2 * np.pi)
         return ps.sum(2)  # sum over d
-
 
     @staticmethod
     def parameterise(x) -> Tensor:

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -56,6 +56,7 @@ class Euclid(Manifold):
     def prms(self) -> Tensor:
         return self.mu
 
+
     def transform(self, x: Tensor,
                   batch_idxs: Optional[List[int]] = None) -> Tensor:
         mu = self.prms
@@ -63,10 +64,16 @@ class Euclid(Manifold):
             mu = mu[batch_idxs]
         return self.gmul(mu, x)
 
+
     def lprior(self, g):
         '''need empirical data here. g is (n_b x m x d)'''
         ps = -0.5 * torch.square(g) - 0.5 * np.log(2 * np.pi)
         return ps.sum(2)  # sum over d
+
+
+    @staticmethod
+    def parameterise(x) -> Tensor:
+        return x
 
     @staticmethod
     def log_q(log_base_prob, x, d=None, kmax=None):

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -77,6 +77,11 @@ class S3(Manifold):
         return self.gmul(mu, x)  # group multiplication
 
     @staticmethod
+    def parameterise(x) -> Tensor:
+        norms = torch.norm(x, dim=1, keepdim=True)
+        return x / norms
+
+    @staticmethod
     def expmap(x: Tensor, dim: int = -1) -> Tensor:
         '''same as SO(3)'''
         theta = torch.norm(x, dim=dim, keepdim=True)

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -14,24 +14,11 @@ class S3(Manifold):
     # log of the uniform prior (negative log volume)
     log_uniform = (special.loggamma(2) - np.log(2) - 2 * np.log(np.pi))
 
-    def __init__(self,
-                 m: int,
-                 d: Optional[int] = None,
-                 mu: Optional[np.ndarray] = None,
-                 Tinds: Optional[np.ndarray] = None,
-                 initialization: Optional[str] = 'identity',
-                 Y: Optional[np.ndarray] = None):
+    def __init__(self, m: int, d: Optional[int] = None):
         super().__init__(d=3)
 
         self.m = m
         self.d2 = 4  # dimensionality of the group parameterization
-
-        mudata = self.initialize(initialization, m, d, Y)
-        if mu is not None:
-            mudata[Tinds, ...] = torch.tensor(mu,
-                                              dtype=torch.get_default_dtype())
-
-        self.mu = nn.Parameter(data=mudata, requires_grad=True)
 
         # per condition
         self.lprior_const = torch.tensor(
@@ -57,24 +44,11 @@ class S3(Manifold):
                               parameterise=lambda x: self.expmap2(x, dim=-2))
 
     @property
-    def prms(self) -> Tensor:
-        mu = self.mu
-        norms = torch.norm(mu, dim=1, keepdim=True)
-        return mu / norms
-
-    @property
     def name(self):
         return 'S(' + str(self.d) + ')'
 
     def lprior(self, g):
         return self.lprior_const * torch.ones(g.shape[:2])
-
-    def transform(self, x: Tensor,
-                  batch_idxs: Optional[List[int]] = None) -> Tensor:
-        mu = self.prms
-        if batch_idxs is not None:
-            mu = mu[batch_idxs]
-        return self.gmul(mu, x)  # group multiplication
 
     @staticmethod
     def parameterise(x) -> Tensor:

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -77,6 +77,11 @@ class So3(Manifold):
         return self.gmul(mu, x)  # group multiplication
 
     @staticmethod
+    def parameterise(x) -> Tensor:
+        norms = torch.norm(x, dim=1, keepdim=True)
+        return x / norms
+
+    @staticmethod
     def expmap(x: Tensor, dim: int = -1, jitter=1e-8) -> Tensor:
         '''
         x \in R^3 -> q \in R^4 s.t. ||q|| = 1

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -11,28 +11,14 @@ from ..inducing_variables import InducingPoints
 
 
 class So3(Manifold):
-
     # log of the uniform prior (negative log volume)
     log_uniform = (special.loggamma(2) - np.log(1) - 2 * np.log(np.pi))
 
-    def __init__(self,
-                 m: int,
-                 d: Optional[int] = None,
-                 mu: Optional[np.ndarray] = None,
-                 Tinds: Optional[np.ndarray] = None,
-                 initialization: Optional[str] = 'identity',
-                 Y: Optional[np.ndarray] = None):
+    def __init__(self, m: int, d: Optional[int] = None):
         super().__init__(d=3)
 
         self.m = m
         self.d2 = 4  # dimensionality of the group parameterization
-
-        mudata = self.initialize(initialization, m, d, Y)
-        if mu is not None:
-            mudata[Tinds, ...] = torch.tensor(mu,
-                                              dtype=torch.get_default_dtype())
-
-        self.mu = nn.Parameter(data=mudata, requires_grad=True)
 
         # per condition
         self.lprior_const = torch.tensor(
@@ -57,24 +43,11 @@ class So3(Manifold):
                               parameterise=lambda x: self.expmap2(x, dim=-2))
 
     @property
-    def prms(self) -> Tensor:
-        mu = self.mu
-        norms = torch.norm(mu, dim=1, keepdim=True)
-        return mu / norms
-
-    @property
     def name(self):
         return 'So3(' + str(self.d) + ')'
 
     def lprior(self, g):
         return self.lprior_const * torch.ones(g.shape[:2])
-
-    def transform(self, x: Tensor,
-                  batch_idxs: Optional[List[int]] = None) -> Tensor:
-        mu = self.prms
-        if batch_idxs is not None:
-            mu = mu[batch_idxs]
-        return self.gmul(mu, x)  # group multiplication
 
     @staticmethod
     def parameterise(x) -> Tensor:

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -72,6 +72,10 @@ class Torus(Manifold):
         return 'Torus(' + str(self.d) + ')'
 
     @staticmethod
+    def parameterise(x) -> Tensor:
+        return x
+
+    @staticmethod
     def expmap(x: Tensor) -> Tensor:
         '''move to [-pi, pi]'''
         return (x + np.pi) % (2 * np.pi) - np.pi

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -9,23 +9,10 @@ from sklearn import decomposition
 
 
 class Torus(Manifold):
-    def __init__(self,
-                 m: int,
-                 d: int,
-                 mu: Optional[np.ndarray] = None,
-                 Tinds: Optional[np.ndarray] = None,
-                 initialization: Optional[str] = 'random',
-                 Y: Optional[np.ndarray] = None):
+    def __init__(self, m: int, d: int):
         super().__init__(d)
         self.m = m
         self.d2 = d  # dimensionality of the group parameterization
-
-        mudata = self.initialize(initialization, m, d, Y)
-        if mu is not None:
-            mudata[Tinds, ...] = torch.tensor(mu,
-                                              dtype=torch.get_default_dtype())
-
-        self.mu = nn.Parameter(data=mudata, requires_grad=True)
 
         # per condition
         self.lprior_const = torch.tensor(-self.d * np.log(2 * np.pi))
@@ -49,18 +36,8 @@ class Torus(Manifold):
         z = torch.rand(n, self.d, n_z) * 2 * np.pi if z is None else z
         return InducingPoints(n, self.d, n_z, z=z)
 
-    @property
-    def prms(self) -> Tensor:
-        return self.mu
-
     def lprior(self, g: Tensor) -> Tensor:
         return self.lprior_const * torch.ones(g.shape[:2])
-
-    def transform(self, x, mu=None, batch_idxs=None):
-        mu = self.prms
-        if batch_idxs is not None:
-            mu = mu[batch_idxs]
-        return self.gmul(mu, x)
 
     # log of the uniform prior (negative log volume) for T^d
     @property

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -13,6 +13,7 @@ from ..inducing_variables import InducingPoints
 from ..kernels import Kernel
 from ..likelihoods import Likelihood
 from ..lpriors.common import Lprior
+from ..rdist import Rdist
 
 
 class SvgpLvm(nn.Module):
@@ -23,7 +24,7 @@ class SvgpLvm(nn.Module):
                  z: InducingPoints,
                  kernel: Kernel,
                  likelihood: Likelihood,
-                 lat_dist,
+                 lat_dist: Rdist,
                  lprior=Lprior,
                  whiten: bool = True):
         """

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -88,12 +88,12 @@ class SvgpLvm(nn.Module):
         ELBO of the model per batch is [ svgp_lik - svgp_kl - kl ]
         """
 
+        _, _, n_samples = data.shape  #n x mx x n_samples
+        g, lq = self.lat_dist.sample(torch.Size([n_mc]), data, batch_idxs)
+        # g is shape (n_mc, m, d)
+
         data = data if batch_idxs is None else data[:, batch_idxs, :]
         ts = ts if (ts is None or batch_idxs is None) else ts[batch_idxs]
-
-        _, _, n_samples = data.shape  #n x mx x n_samples
-        g, lq = self.lat_dist.sample(torch.Size([n_mc]), batch_idxs)
-        # g is shape (n_mc, m, d)
 
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)
         # and so we need to permute [ g ] to have the right dimensions

--- a/mgplvm/rdist/__init__.py
+++ b/mgplvm/rdist/__init__.py
@@ -1,2 +1,2 @@
 from .common import Rdist
-from .relie import (ReLie, ReLieAmortized)
+from .relie import (ReLie, ReLieBase)

--- a/mgplvm/rdist/__init__.py
+++ b/mgplvm/rdist/__init__.py
@@ -1,2 +1,2 @@
-from .common import Rdist
-from .relie import (ReLieBase, ReLie)
+from .common import Rdist, RdistAmortized
+from .relie import (ReLie, ReLieAmortized)

--- a/mgplvm/rdist/__init__.py
+++ b/mgplvm/rdist/__init__.py
@@ -1,2 +1,2 @@
-from .common import Rdist, RdistAmortized
+from .common import Rdist
 from .relie import (ReLie, ReLieAmortized)

--- a/mgplvm/rdist/common.py
+++ b/mgplvm/rdist/common.py
@@ -10,7 +10,7 @@ class Rdist(Module, metaclass=abc.ABCMeta):
         super(Rdist, self).__init__()
         self.manif = manif
         self.d = manif.d
-        self.m = manif.m
+        self.m = m
         self.kmax = kmax
 
     @abc.abstractmethod
@@ -27,11 +27,10 @@ class Rdist(Module, metaclass=abc.ABCMeta):
 
 
 class RdistAmortized(Module, metaclass=abc.ABCMeta):
-    def __init__(self, manif: Manifold, m: int, kmax: int):
-        super(Rdist, self).__init__()
+    def __init__(self, manif: Manifold, kmax: int):
+        super(RdistAmortized, self).__init__()
         self.manif = manif
         self.d = manif.d
-        self.m = manif.m
         self.kmax = kmax
 
     @abc.abstractmethod

--- a/mgplvm/rdist/common.py
+++ b/mgplvm/rdist/common.py
@@ -1,11 +1,47 @@
+import abc
+from torch import Tensor
 from ..base import Module
 from ..manifolds.base import Manifold
+from typing import Tuple
 
 
-class Rdist(Module):
+class Rdist(Module, metaclass=abc.ABCMeta):
     def __init__(self, manif: Manifold, m: int, kmax: int):
         super(Rdist, self).__init__()
         self.manif = manif
         self.d = manif.d
         self.m = manif.m
         self.kmax = kmax
+
+    @abc.abstractmethod
+    def lat_gmu(self) -> Tensor:
+        pass
+
+    @abc.abstractmethod
+    def lat_gamma(self) -> Tensor:
+        pass
+
+    @abc.abstractmethod
+    def lat_prms(self) -> Tuple[Tensor, Tensor]:
+        pass
+
+
+class RdistAmortized(Module, metaclass=abc.ABCMeta):
+    def __init__(self, manif: Manifold, m: int, kmax: int):
+        super(Rdist, self).__init__()
+        self.manif = manif
+        self.d = manif.d
+        self.m = manif.m
+        self.kmax = kmax
+
+    @abc.abstractmethod
+    def lat_gmu(self, Y) -> Tensor:
+        pass
+
+    @abc.abstractmethod
+    def lat_gamma(self, Y) -> Tensor:
+        pass
+
+    @abc.abstractmethod
+    def lat_prms(self, Y) -> Tuple[Tensor, Tensor]:
+        pass

--- a/mgplvm/rdist/common.py
+++ b/mgplvm/rdist/common.py
@@ -6,41 +6,24 @@ from typing import Tuple
 
 
 class Rdist(Module, metaclass=abc.ABCMeta):
-    def __init__(self, manif: Manifold, m: int, kmax: int):
+    def __init__(self, manif: Manifold, kmax: int):
         super(Rdist, self).__init__()
         self.manif = manif
         self.d = manif.d
-        self.m = m
         self.kmax = kmax
 
     @abc.abstractmethod
-    def lat_gmu(self) -> Tensor:
+    def lat_gmu(self, Y, batch_idxs) -> Tensor:
         pass
 
     @abc.abstractmethod
-    def lat_gamma(self) -> Tensor:
+    def lat_gamma(self, Y, batch_idxs) -> Tensor:
         pass
 
     @abc.abstractmethod
-    def lat_prms(self) -> Tuple[Tensor, Tensor]:
-        pass
-
-
-class RdistAmortized(Module, metaclass=abc.ABCMeta):
-    def __init__(self, manif: Manifold, kmax: int):
-        super(RdistAmortized, self).__init__()
-        self.manif = manif
-        self.d = manif.d
-        self.kmax = kmax
-
-    @abc.abstractmethod
-    def lat_gmu(self, Y) -> Tensor:
+    def lat_prms(self, Y, batch_idxs) -> Tuple[Tensor, Tensor]:
         pass
 
     @abc.abstractmethod
-    def lat_gamma(self, Y) -> Tensor:
-        pass
-
-    @abc.abstractmethod
-    def lat_prms(self, Y) -> Tuple[Tensor, Tensor]:
+    def sample(self, size, Y, batch_idxs, kmax) -> Tuple[Tensor, Tensor]:
         pass

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -139,5 +139,8 @@ class ReLie(ReLieBase):
         gtilde = self.manif.expmap(x)
 
         # apply g_mu with dims: (n_mc x m x d)
-        g = self.manif.gmul(gmu, gtilde)
+        if batch_idxs is not None:
+            g = self.manif.gmul(gmu[batch_idxs], gtilde)
+        else:
+            g = self.manif.gmul(gmu, gtilde)
         return g, lq

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -1,3 +1,4 @@
+import abc
 import torch
 from torch import nn, Tensor
 from torch.distributions.multivariate_normal import MultivariateNormal
@@ -5,52 +6,11 @@ from torch.distributions.normal import Normal
 from torch.distributions import transform_to, constraints
 from ..utils import softplus, inv_softplus
 from ..manifolds.base import Manifold
-from .common import Rdist
+from .common import Rdist, RdistAmortized
 from typing import Optional
 
 
-class ReLieBase(Rdist):
-    name = "ReLieBase"
-
-    def __init__(self, manif: Manifold, m: int, kmax: int = 5):
-        super(ReLieBase, self).__init__(manif, m, kmax)
-
-    def mvn(self, gamma, batch_idxs=None):
-        mu = torch.zeros(self.m, self.d).to(gamma.device)
-
-        if batch_idxs is not None:
-            mu = mu[batch_idxs]
-            gamma = gamma[batch_idxs]
-        return MultivariateNormal(mu, scale_tril=gamma)
-
-    def sample(self, gmu, gamma, size, batch_idxs=None, kmax=5):
-        """
-        generate samples and computes its log entropy
-        """
-        q = self.mvn(gamma, batch_idxs)
-        # sample a batch with dims: (n_mc x batch_size x d)
-        x = q.rsample(size)
-        gamma = self.prms
-        mu = torch.zeros(self.m).to(gamma.device)
-        if batch_idxs is not None:
-            gamma, mu = gamma[batch_idxs], mu[batch_idxs]
-        mu = mu[..., None]
-        lq = torch.stack([
-            self.manif.log_q(
-                Normal(mu, gamma[..., j, j][..., None]).log_prob,
-                x[..., j, None], 1, self.kmax).sum(dim=-1)
-            for j in range(self.d)
-        ]).sum(dim=0)
-
-        # transform x to group with dims (n_mc x m x d)
-        gtilde = self.manif.expmap(x)
-
-        # apply g_mu with dims: (n_mc x m x d)
-        g = self.manif.gmul(gmu[batch_idxs], gtilde)
-        return g, lq
-
-
-class ReLie(ReLieBase):
+class ReLie(Rdist):
     name = "ReLie"
 
     def __init__(self,
@@ -94,15 +54,26 @@ class ReLie(ReLieBase):
         else:
             self.gamma = nn.Parameter(data=gamma, requires_grad=True)
 
-    @property
-    def prms(self):
+    def lat_gmu(self):
         gmu = self.manif.parameterise(self.gmu)
+        return gmu
+
+    def lat_gamma(self):
         if self.diagonal:
             gamma = torch.diag_embed(softplus(self.gamma))
         else:
             gamma = torch.distributions.transform_to(
                 MultivariateNormal.arg_constraints['scale_tril'])(self.gamma)
+        return gamma
+
+    @property
+    def prms(self):
+        gmu = self.lat_gmu()
+        gamma = self.lat_gamma()
         return gmu, gamma
+
+    def lat_prms(self):
+        return self.prms
 
     def mvn(self, gamma=None, batch_idxs=None):
         gamma = self.prms[1] if gamma is None else gamma
@@ -144,4 +115,63 @@ class ReLie(ReLieBase):
             g = self.manif.gmul(gmu[batch_idxs], gtilde)
         else:
             g = self.manif.gmul(gmu, gtilde)
+        return g, lq
+
+
+class ReLieAmortized(RdistAmortized):
+    name = "ReLieAmortized"
+
+    def __init__(self, manif: Manifold, f, m: int, kmax: int = 5):
+        super(ReLieAmortized, self).__init__(manif, m, kmax)
+        self.f = f
+
+    def lat_prms(self, Y):
+        gmu, gamma = self.f(Y)
+        return gmu, gamma
+
+    def lat_gmu(self, Y):
+        return self.lat_prms(Y)[0]
+
+    def lat_gamma(self, Y):
+        return self.lat_prms(Y)[1]
+
+
+    @property
+    def prms(self):
+        self.f.prms
+
+
+
+    def mvn(self, gamma, batch_idxs=None):
+        mu = torch.zeros(self.m, self.d).to(gamma.device)
+
+        if batch_idxs is not None:
+            mu = mu[batch_idxs]
+            gamma = gamma[batch_idxs]
+        return MultivariateNormal(mu, scale_tril=gamma)
+
+    def sample(self, gmu, gamma, size, batch_idxs=None, kmax=5):
+        """
+        generate samples and computes its log entropy
+        """
+        q = self.mvn(gamma, batch_idxs)
+        # sample a batch with dims: (n_mc x batch_size x d)
+        x = q.rsample(size)
+        gamma = self.prms
+        mu = torch.zeros(self.m).to(gamma.device)
+        if batch_idxs is not None:
+            gamma, mu = gamma[batch_idxs], mu[batch_idxs]
+        mu = mu[..., None]
+        lq = torch.stack([
+            self.manif.log_q(
+                Normal(mu, gamma[..., j, j][..., None]).log_prob,
+                x[..., j, None], 1, self.kmax).sum(dim=-1)
+            for j in range(self.d)
+        ]).sum(dim=0)
+
+        # transform x to group with dims (n_mc x m x d)
+        gtilde = self.manif.expmap(x)
+
+        # apply g_mu with dims: (n_mc x m x d)
+        g = self.manif.gmul(gmu[batch_idxs], gtilde)
         return g, lq

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -62,7 +62,8 @@ class ReLie(ReLieBase):
                  Tinds=None,
                  fixed_gamma=False,
                  diagonal=False,
-                 initialization: Optional[str] = 'random'):
+                 initialization: Optional[str] = 'random',
+                 Y=None):
         '''
         Notes
         -----
@@ -76,7 +77,7 @@ class ReLie(ReLieBase):
         super(ReLie, self).__init__(manif, m, kmax)
         self.diagonal = diagonal
 
-        gmudata = self.manif.initialize(initialization, self.m, self.d, None)
+        gmudata = self.manif.initialize(initialization, self.m, self.d, Y)
         self.gmu = nn.Parameter(data=gmudata, requires_grad=True)
 
         gamma = torch.ones(m, self.d) * sigma

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -6,11 +6,113 @@ from torch.distributions.normal import Normal
 from torch.distributions import transform_to, constraints
 from ..utils import softplus, inv_softplus
 from ..manifolds.base import Manifold
-from .common import Rdist, RdistAmortized
+from .common import Rdist
 from typing import Optional
+from ..base import Module
 
 
-class ReLie(Rdist):
+class ReLieAmortized(Rdist):
+    name = "ReLieAmortized"
+
+    def __init__(self, manif: Manifold, f, kmax: int = 5):
+        super(ReLieAmortized, self).__init__(manif, kmax)
+        self.f = f
+
+    def lat_prms(self, Y=None, batch_idxs=None):
+        gmu, gamma = self.f(Y, batch_idxs)
+        return gmu, gamma
+
+    def lat_gmu(self, Y=None, batch_idxs=None):
+        return self.lat_prms(Y)[0]
+
+    def lat_gamma(self, Y=None, batch_idxs=None):
+        return self.lat_prms(Y, batch_idxs)[1]
+
+    @property
+    def prms(self):
+        self.f.prms
+
+    def mvn(self, gamma=None):
+        gamma = self.lat_gamma() if gamma is None else gamma
+        m = gamma.shape[0]
+        mu = torch.zeros(m, self.d).to(gamma.device)
+        return MultivariateNormal(mu, scale_tril=gamma)
+
+    def sample(self, size, Y=None, batch_idxs=None, kmax=5):
+        """
+        generate samples and computes its log entropy
+        """
+        gmu, gamma = self.lat_prms(Y, batch_idxs)
+        q = self.mvn(gamma)
+        # sample a batch with dims: (n_mc x batch_size x d)
+        x = q.rsample(size)
+        m = x.shape[1]
+        mu = torch.zeros(m).to(gamma.device)[..., None]
+        lq = torch.stack([
+            self.manif.log_q(
+                Normal(mu, gamma[..., j, j][..., None]).log_prob,
+                x[..., j, None], 1, self.kmax).sum(dim=-1)
+            for j in range(self.d)
+        ]).sum(dim=0)
+        gtilde = self.manif.expmap(x)
+
+        # apply g_mu with dims: (n_mc x m x d)
+        g = self.manif.gmul(gmu, gtilde)
+        return g, lq
+
+
+class _F(Module):
+    def __init__(self,
+                 manif: Manifold,
+                 m: int,
+                 kmax: int = 5,
+                 sigma: float = 1.5,
+                 gammas: Optional[Tensor] = None,
+                 Tinds=None,
+                 fixed_gamma=False,
+                 diagonal=False,
+                 initialization: Optional[str] = 'random',
+                 Y=None):
+
+        super(_F, self).__init__()
+        self.manif = manif
+        gmudata = self.manif.initialize(initialization, m, manif.d, Y)
+        self.gmu = nn.Parameter(data=gmudata, requires_grad=True)
+        self.diagonal = diagonal
+
+        gamma = torch.ones(m, manif.d) * sigma
+        gamma = inv_softplus(gamma) if diagonal else torch.diag_embed(gamma)
+        if gammas is not None:
+            gamma[Tinds, ...] = torch.tensor(gammas,
+                                             dtype=torch.get_default_dtype())
+
+        if not diagonal:
+            gamma = transform_to(constraints.lower_cholesky).inv(gamma)
+
+        if fixed_gamma:  #don't update the covariance matrix
+            self.gamma = nn.Parameter(data=gamma, requires_grad=False)
+        else:
+            self.gamma = nn.Parameter(data=gamma, requires_grad=True)
+
+    def forward(self, Y=None, batch_idxs=None):
+        gmu, gamma = self.prms
+        if batch_idxs is None:
+            return gmu, gamma
+        else:
+            return gmu[batch_idxs], gamma[batch_idxs]
+
+    @property
+    def prms(self):
+        gmu = self.manif.parameterise(self.gmu)
+        if self.diagonal:
+            gamma = torch.diag_embed(softplus(self.gamma))
+        else:
+            gamma = torch.distributions.transform_to(
+                MultivariateNormal.arg_constraints['scale_tril'])(self.gamma)
+        return gmu, gamma
+
+
+class ReLie(ReLieAmortized):
     name = "ReLie"
 
     def __init__(self,
@@ -34,133 +136,11 @@ class ReLie(Rdist):
         The diagonal approximation is useful for T^n as it saves an exponentially growing ReLie complexity
         The diagonal approximation only works for T^n and R^n
         '''
-        super(ReLie, self).__init__(manif, m, kmax)
-        self.diagonal = diagonal
 
-        gmudata = self.manif.initialize(initialization, self.m, self.d, Y)
-        self.gmu = nn.Parameter(data=gmudata, requires_grad=True)
-
-        gamma = torch.ones(m, self.d) * sigma
-        gamma = inv_softplus(gamma) if diagonal else torch.diag_embed(gamma)
-        if gammas is not None:
-            gamma[Tinds, ...] = torch.tensor(gammas,
-                                             dtype=torch.get_default_dtype())
-
-        if not diagonal:
-            gamma = transform_to(constraints.lower_cholesky).inv(gamma)
-
-        if fixed_gamma:  #don't update the covariance matrix
-            self.gamma = nn.Parameter(data=gamma, requires_grad=False)
-        else:
-            self.gamma = nn.Parameter(data=gamma, requires_grad=True)
-
-    def lat_gmu(self):
-        gmu = self.manif.parameterise(self.gmu)
-        return gmu
-
-    def lat_gamma(self):
-        if self.diagonal:
-            gamma = torch.diag_embed(softplus(self.gamma))
-        else:
-            gamma = torch.distributions.transform_to(
-                MultivariateNormal.arg_constraints['scale_tril'])(self.gamma)
-        return gamma
+        f = _F(manif, m, kmax, sigma, gammas, Tinds, fixed_gamma, diagonal,
+               initialization, Y)
+        super(ReLie, self).__init__(manif, f, kmax)
 
     @property
     def prms(self):
-        gmu = self.lat_gmu()
-        gamma = self.lat_gamma()
-        return gmu, gamma
-
-    def lat_prms(self):
-        return self.prms
-
-    def mvn(self, gamma=None, batch_idxs=None):
-        gamma = self.prms[1] if gamma is None else gamma
-        mu = torch.zeros(self.m, self.d).to(gamma.device)
-        if batch_idxs is not None:
-            mu = mu[batch_idxs]
-            gamma = gamma[batch_idxs]
-        return MultivariateNormal(mu, scale_tril=gamma)
-
-    def sample(self, size, batch_idxs=None, kmax=5):
-        """
-        generate samples and computes its log entropy
-        """
-        gmu, gamma = self.prms
-        q = self.mvn(gamma, batch_idxs)
-        # sample a batch with dims: (n_mc x batch_size x d)
-        x = q.rsample(size)
-
-        if self.diagonal:  #consider factorized variational distribution
-            gamma = self.prms
-            mu = torch.zeros(self.m).to(gamma.device)
-            if batch_idxs is not None:
-                gamma, mu = gamma[batch_idxs], mu[batch_idxs]
-            mu = mu[..., None]
-            lq = torch.stack([
-                self.manif.log_q(
-                    Normal(mu, gamma[..., j, j][..., None]).log_prob,
-                    x[..., j, None], 1, self.kmax).sum(dim=-1)
-                for j in range(self.d)
-            ]).sum(dim=0)
-        else:
-            lq = self.manif.log_q(q.log_prob, x, self.manif.d, self.kmax)
-
-        # transform x to group with dims (n_mc x m x d)
-        gtilde = self.manif.expmap(x)
-
-        # apply g_mu with dims: (n_mc x m x d)
-        if batch_idxs is not None:
-            g = self.manif.gmul(gmu[batch_idxs], gtilde)
-        else:
-            g = self.manif.gmul(gmu, gtilde)
-        return g, lq
-
-
-class ReLieAmortized(RdistAmortized):
-    name = "ReLieAmortized"
-
-    def __init__(self, manif: Manifold, f, kmax: int = 5):
-        super(ReLieAmortized, self).__init__(manif, kmax)
-        self.f = f
-
-    def lat_prms(self, Y):
-        gmu, gamma = self.f(Y)
-        return gmu, gamma
-
-    def lat_gmu(self, Y):
-        return self.lat_prms(Y)[0]
-
-    def lat_gamma(self, Y):
-        return self.lat_prms(Y)[1]
-
-    @property
-    def prms(self):
-        self.f.prms
-
-    def mvn(self, m, gamma):
-        mu = torch.zeros(m, self.d).to(gamma.device)
-        return MultivariateNormal(mu, scale_tril=gamma)
-
-    def sample(self, Y, size, kmax=5):
-        """
-        generate samples and computes its log entropy
-        """
-        m = Y.shape[1]
-        gmu, gamma = self.lat_prms(Y)
-        q = self.mvn(m, gamma)
-        # sample a batch with dims: (n_mc x batch_size x d)
-        x = q.rsample(size)
-        mu = torch.zeros(m).to(gamma.device)[..., None]
-        lq = torch.stack([
-            self.manif.log_q(
-                Normal(mu, gamma[..., j, j][..., None]).log_prob,
-                x[..., j, None], 1, self.kmax).sum(dim=-1)
-            for j in range(self.d)
-        ]).sum(dim=0)
-        gtilde = self.manif.expmap(x)
-
-        # apply g_mu with dims: (n_mc x m x d)
-        g = self.manif.gmul(gmu, gtilde)
-        return g, lq
+        return self.f.prms

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -11,11 +11,11 @@ from typing import Optional
 from ..base import Module
 
 
-class ReLieAmortized(Rdist):
-    name = "ReLieAmortized"
+class ReLieBase(Rdist):
+    name = "ReLieBase"
 
     def __init__(self, manif: Manifold, f, kmax: int = 5):
-        super(ReLieAmortized, self).__init__(manif, kmax)
+        super(ReLieBase, self).__init__(manif, kmax)
         self.f = f
 
     def lat_prms(self, Y=None, batch_idxs=None):
@@ -112,7 +112,7 @@ class _F(Module):
         return gmu, gamma
 
 
-class ReLie(ReLieAmortized):
+class ReLie(ReLieBase):
     name = "ReLie"
 
     def __init__(self,

--- a/mgplvm/training.py
+++ b/mgplvm/training.py
@@ -124,8 +124,8 @@ def sort_params(model, hook, trainGP, svgp=False):
                 param == model.lat_dist.gamma):
             param.register_hook(hook)  # option to mask gradients
             params[1].append(param)
-        elif (param.shape == model.lat_dist.manif.mu.shape) and torch.all(
-                param == model.lat_dist.manif.mu):
+        elif (param.shape == model.lat_dist.prms[0].shape) and torch.all(
+                param == model.lat_dist.prms[0]):
             param.register_hook(hook)  # option to mask gradients
             params[0].append(param)
         elif svgp and (param.shape == model.svgp.q_mu.shape) and torch.all(
@@ -258,7 +258,7 @@ def svgp(Y,
         if i % print_every == 0:
             mu_mag = np.mean(
                 np.sqrt(
-                    np.sum(model.lat_dist.manif.prms.data.cpu().numpy()[:]**2,
+                    np.sum(model.lat_dist.prms[0].data.cpu().numpy()[:]**2,
                            axis=1)))
             sig = np.median(
                 np.concatenate([

--- a/mgplvm/training.py
+++ b/mgplvm/training.py
@@ -118,10 +118,9 @@ def sort_params(model, hook, trainGP, svgp=False):
     # parameters to be optimized
 
     params: List[List[Tensor]] = [[], [], []] if svgp else [[], []]
-
     for param in model.parameters():
-        if (param.shape == model.lat_dist.gamma.shape) and torch.all(
-                param == model.lat_dist.gamma):
+        if (param.shape == model.lat_dist.prms[1].shape) and torch.all(
+                param == model.lat_dist.prms[1]):
             param.register_hook(hook)  # option to mask gradients
             params[1].append(param)
         elif (param.shape == model.lat_dist.prms[0].shape) and torch.all(

--- a/mgplvm/training.py
+++ b/mgplvm/training.py
@@ -263,7 +263,7 @@ def svgp(Y,
             sig = np.median(
                 np.concatenate([
                     np.diag(sig)
-                    for sig in model.lat_dist.prms.data.cpu().numpy()
+                    for sig in model.lat_dist.prms[1].data.cpu().numpy()
                 ]))
             msg = ('\riter {:3d} | elbo {:.3f} | kl {:.3f} | loss {:.3f} ' +
                    '| |mu| {:.3f} | sig {:.3f} |').format(

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -79,8 +79,8 @@ def test_kernels_run():
     ]
     for kernel in kernels:
         # specify manifold, kernel and rdist
-        manif = Euclid(m, d, initialization='random')
-        lat_dist = mgplvm.rdist.ReLie(manif, m)
+        manif = Euclid(m, d)
+        lat_dist = mgplvm.rdist.ReLie(manif, m, initialization='random')
         # generate model
         lik = likelihoods.Gaussian(n)
         lprior = lpriors.Uniform(manif)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -71,7 +71,7 @@ def test_GP_prior():
     data = torch.tensor(Y).to(device)
     ts = torch.arange(m).to(device)
     _, _, n_samples = data.shape  #n x mx x n_samples
-    g, lq = mod.lat_dist.sample(torch.Size([n_mc]), None)
+    g, lq = mod.lat_dist.sample(torch.Size([n_mc]), data, None)
 
     x = g  #input to prior
 

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -28,10 +28,14 @@ def test_GP_prior():
     Y = gen.gen_data(ell=25, sig=1)
 
     # specify manifold, kernel and rdist
-    manif = Euclid(m, d, initialization='random', Y=Y[:, :, 0])
+    manif = Euclid(m, d)
 
     #lat_dist = mgplvm.rdist.MVN(m, d, sigma=sig0)
-    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=sig0)
+    lat_dist = mgplvm.rdist.ReLie(manif,
+                                  m,
+                                  sigma=sig0,
+                                  initialization='random',
+                                  Y=Y[:, :, 0])
     alpha = np.mean(np.std(Y, axis=1), axis=1)
     kernel = kernels.QuadExp(n, manif.distance, alpha=alpha)
 


### PR DESCRIPTION
-  I've moved the `gmu` parameter from the manifolds to `ReLie`. This simplifies the API of the manifolds and also puts the latent parameters `gmu` and `gamma` inside the `rdist` object. (@KrisJensen  thoughts?)
-  `ReLieBase` can be initialized with a NN module `f` which outputs the latent mean `gmu` and covariance `gamma`. In the future `f` can be any recognition network that we want.
- for now I have implemented `ReLie` as a subclass of `ReLieBase`, by writing the corresponding module `_F` (see `relie.py`)