### PR TITLE
Update latents means and covariance initialization & parameterization

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -17,6 +17,7 @@ def model_params(n, m, d, n_z, **kwargs):
         'initialization': 'pca',
         'Y': None,
         'latent_sigma': 1,
+        'latent_mu': None,
         'diagonal': True,
         'learn_linear_weights': False,
         'learn_linear_alpha': True,
@@ -51,7 +52,8 @@ def load_model(params):
         
     #### specify latent distribution ####
     lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=params['latent_sigma'], diagonal = params['diagonal'],
-                                 initialization = params['initialization'], Y = params['Y'])
+                                 initialization = params['initialization'], Y = params['Y'],
+                                 mu = params['latent_mu'])
     
     #### specify kernel ####
     if params['kernel'] == 'linear':

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -42,13 +42,13 @@ def train_cv(mod,
         GPU/CPU device on which to run the calculations
     train_ps : dict
         dictionary of training parameters. Constructed by crossval.training_params()
-    T1 [optional] : int list
+    T1 : Optional[int list]
         indices of the conditions to use for training
-    N1 [optional] : int list
+    N1 : Optional[int list]
         indices of the neurons to use for training
-    nt_train [optional] : int
+    nt_train : Optional[int]
         number of randomly selected conditions to use for training
-    nn_train [optional] : int
+    nn_train : Optional[int]
         number of randomly selected neurons to use for training
 
     Returns
@@ -70,7 +70,7 @@ def train_cv(mod,
     split = {'Y': Y, 'N1': N1, 'T1': T1}
     
     train_ps1 = update_params(train_ps, batch_pool = T1)
-    mod = train_model(mod, Y, device, train_ps1)
+    _ = train_model(mod, Y, device, train_ps1)
     
     ### construct a mask for some of the time points ####
     def mask_Ts(grad):
@@ -85,7 +85,7 @@ def train_cv(mod,
     for p in mod.lat_dist.parameters(): #only gradients for the latent distribution
         p.requires_grad = True
     
-    mod = train_model(mod, Y, device, train_ps2)
+    _ = train_model(mod, Y, device, train_ps2)
     
     if test:
         _ = test_cv(mod, split, device, n_mc = train_ps['n_mc'], Print = True)

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -84,13 +84,6 @@ def train_cv(mod,
         p.requires_grad = False
     for p in mod.lat_dist.parameters(): #only gradients for the latent distribution
         p.requires_grad = True
-    '''
-    lat_params = list(mod.lat_dist.parameters())
-    for p in mod.parameters():
-        matches = [(p.shape == lat_p.shape and torch.all(p == lat_p)) for lat_p in lat_params]
-        if not any(matches):
-            p.requires_grad = False
-    '''
     
     mod = train_model(mod, Y, device, train_ps2)
     
@@ -108,7 +101,7 @@ def test_cv(mod, split, device, n_mc = 32, Print = False):
     T2, N2 = not_in(np.arange(m), T1), not_in(np.arange(n), N1)
 
     #generate prediction for held out data#
-    Ytest = Y[N2, :, :][:, T2]
+    Ytest = Y[N2, ...][:, T2, :]
     latents = mod.lat_dist.prms[0].detach()[T2, ...] #latent means
     Ypred, var = mod.svgp.predict(latents.T[None, ...], False)
     Ypred = Ypred.detach().cpu().numpy()[0, N2, :, :]

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -40,10 +40,10 @@ def train_model(mod, Y, device, params):
                            lrate=params['lrate'], 
                            print_every=params['print_every'],
                             batch_size = params['batch_size'],
-                           callback = params['callback'],
+                           stop = params['callback'],
                             ts = params['ts'],
                             batch_pool = params['batch_pool'],
                             neuron_idxs = params['neuron_idxs'],
-                            mask_Ts = params['mask_Ts'])
+                            mask_Ts = params['mask_Ts']),
     
     return trained_mod

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -136,16 +136,16 @@ class ReLie(ReLieBase):
         ----------
         m : int
             number of conditions/timepoints
-        kmax [optional] : int
+        kmax : Optional[int]
             number of terms used in the ReLie approximation is (2kmax+1)
-        sigma [optional] : float
+        sigma : Optional[float]
             initial diagonal std of the variational distribution
-        intialization [optional] : str
+        intialization : Optional[str]
             string to specify type of initialization
             ('random'/'PCA'/'identity' depending on manifold)
-        mu [optional] : np.ndarray
+        mu : Optional[np.ndarray]
             initialization of the vartiational means (m x d2)
-        Y [optional] : np.ndarray
+        Y : Optional[np.ndarray]
             data used to initialize latents (n x m x n_samples)
             
         Notes

--- a/mgplvm/training.py
+++ b/mgplvm/training.py
@@ -212,10 +212,10 @@ def svgp(Y,
          mask_Ts=None,
          neuron_idxs=None):
     '''
-    max_steps [optional]: int, default=1000
+    max_steps : Optional[int], default=1000
         maximum number of training iterations
     
-    batch_pool [optional] : None or int list
+    batch_pool : Optional[int list]
         pool of indices from which to batch (used to train a partial model)
     '''
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2,6 +2,6 @@ import subprocess as sb
 
 sb.call(['python', 'test_entropies.py'])
 sb.call(['python', 'test_kernels.py'])
-sb.call(['python', 'test_manifolds.py'])
 sb.call(['python', 'test_models.py'])
+sb.call(['python', 'test_manifolds.py'])
 sb.call(['python', 'test_priors.py'])

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -1,7 +1,10 @@
 import mgplvm
 from mgplvm import manifolds, rdist, kernels, likelihoods, lpriors, models, training
 import numpy as np
+import torch
 from torch import optim
+torch.set_default_dtype(torch.float64)
+device = mgplvm.utils.get_device()
 
 def test_euclid_dimensions():
     e3 = manifolds.Euclid(10, 3)
@@ -20,31 +23,34 @@ def test_so3_dimensions():
     assert so3.d == 3
     assert so3.m == 10
     
-def test_so3_runs():
+def test_manifs_runs():
     m, d, n, n_z = 10, 3, 5, 5
-    manif = manifolds.So3(m, d)
-    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=0.4)
     Y = np.random.normal(0, 1, (n, m, 1))
-    kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y = Y)
-    # generate model
-    device = mgplvm.utils.get_device()
-    lik = mgplvm.likelihoods.Gaussian(n)
-    lprior = mgplvm.lpriors.Uniform(manif)
-    z = manif.inducing_points(n, n_z)
-    mod = mgplvm.models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
-                         whiten=True).to(device)
+    for i, manif_type in enumerate([manifolds.Torus, manifolds.So3, manifolds.S3]):
+        manif = manif_type(m, d)
+        print(manif.name)
+        lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=0.4, diagonal = (True if i == 0 else False))
+        kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y = Y)
+        # generate model
+        lik = mgplvm.likelihoods.Gaussian(n)
+        lprior = mgplvm.lpriors.Uniform(manif)
+        z = manif.inducing_points(n, n_z)
+        mod = mgplvm.models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+                             whiten=True).to(device)
 
-    # train model
-    trained_model = mgplvm.training.svgp(Y,
-                                  mod,
-                                  device,
-                                  optimizer=optim.Adam,
-                                  print_every=1000)
+        # train model
+        trained_model = mgplvm.training.svgp(Y,
+                                            mod,
+                                            device,
+                                            max_steps = 5,
+                                            n_mc = 64,
+                                            optimizer=optim.Adam,
+                                            print_every=1000)
     
 if __name__ == '__main__':
     test_euclid_dimensions()
     test_torus_dimensions()
     test_so3_dimensions()
-    test_so3_runs()
+    test_manifs_runs()
     print('Tested manifolds')
     

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -1,5 +1,7 @@
-from mgplvm import manifolds
-
+import mgplvm
+from mgplvm import manifolds, rdist, kernels, likelihoods, lpriors, models, training
+import numpy as np
+from torch import optim
 
 def test_euclid_dimensions():
     e3 = manifolds.Euclid(10, 3)
@@ -18,9 +20,31 @@ def test_so3_dimensions():
     assert so3.d == 3
     assert so3.m == 10
     
+def test_so3_runs():
+    m, d, n, n_z = 10, 3, 5, 5
+    manif = manifolds.So3(m, d)
+    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=0.4)
+    Y = np.random.normal(0, 1, (n, m, 1))
+    kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y = Y)
+    # generate model
+    device = mgplvm.utils.get_device()
+    lik = mgplvm.likelihoods.Gaussian(n)
+    lprior = mgplvm.lpriors.Uniform(manif)
+    z = manif.inducing_points(n, n_z)
+    mod = mgplvm.models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+                         whiten=True).to(device)
+
+    # train model
+    trained_model = mgplvm.training.svgp(Y,
+                                  mod,
+                                  device,
+                                  optimizer=optim.Adam,
+                                  print_every=1000)
+    
 if __name__ == '__main__':
     test_euclid_dimensions()
     test_torus_dimensions()
     test_so3_dimensions()
+    test_so3_runs()
     print('Tested manifolds')
     

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,15 +21,15 @@ def test_svgp_runs():
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 1  # number of samples
-    gen = syndata.Gen(syndata.Torus(d), n, m, variability=0.25)
+    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
     sig0 = 1.5
     l = 0.4
     gen.set_param('l', l)
     Y = gen.gen_data()
     Y = Y + np.random.normal(size=Y.shape) * np.mean(Y) / 3
     # specify manifold, kernel and rdist
-    manif = Torus(m, d)
-    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=sig0)
+    manif = Euclid(m, d)
+    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=sig0, diagonal = False)
     # initialize signal variance
     alpha = np.mean(np.std(Y, axis=1), axis=1)
     kernel = kernels.QuadExp(n, manif.distance, alpha=alpha)


### PR DESCRIPTION
Allow for optional specification of initial latent means (useful e.g. in crossvalidation where we might want to initialize half using PCA and half at zero).
Added diagonal flag in ReLieBase to distinguish between computing diagonal entropies (essential for T(d>3)) and entropies using full covariance matrices (necessary for S(3), SO(3)).
test_manifolds.py now tests that Torus, S(3) and SO(3) runs.