### PR TITLE
Work on SO(3) initialization, AR(p) prior and model storage

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -1,6 +1,6 @@
 import mgplvm
 from mgplvm import lpriors, kernels, models
-from mgplvm.manifolds import Euclid, Torus
+from mgplvm.manifolds import Euclid, Torus, So3
 import torch
 import pickle
 import numpy as np
@@ -49,6 +49,9 @@ def load_model(params):
         manif = Euclid(m, d)
     elif params['manifold'] == 'torus':
         manif = Torus(m, d)
+    elif params['manifold'] in ['SO3', 'So3', 'so3', 'SO(3)']:
+        manif = So3(m, 3)
+        params['diagonal'] = False
         
     #### specify latent distribution ####
     lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=params['latent_sigma'], diagonal = params['diagonal'],
@@ -70,7 +73,8 @@ def load_model(params):
         lprior = lpriors.GP(manif, lprior_kernel, n_z = n_z, tmax = m)
     elif params['prior'] == 'ARP':
         lprior = lpriors.ARP(params['arp_p'], manif, ar_eta = torch.tensor(params['arp_eta']),
-                         learn_eta = params['arp_learn_eta'], learn_c = params['arp_learn_c'])
+                         learn_eta = params['arp_learn_eta'], learn_c = params['arp_learn_c'],
+                            diagonal = params['diagonal'])
     else:
         lprior = lpriors.Uniform(manif)
 

--- a/mgplvm/lpriors/__init__.py
+++ b/mgplvm/lpriors/__init__.py
@@ -1,3 +1,3 @@
-from .common import Uniform, Brownian, AR1, ARP, Null, Gaussian, ARP_G
+from .common import Uniform, Brownian, ARP, Null, Gaussian
 from . import torus
 from .euclidean import GP

--- a/mgplvm/lpriors/common.py
+++ b/mgplvm/lpriors/common.py
@@ -179,49 +179,6 @@ class Brownian(Lprior):
             brownian_eta.detach().cpu().numpy().mean())
 
 
-class AR1(Lprior):
-    name = "AR1"
-
-    def __init__(self, manif, kmax=5, ar1_phi=None, ar1_eta=None, ar1_c=None):
-        '''
-        x_t = c + phi x_{t-1} + w_t
-        w_t = N(0, eta)
-        '''
-        super().__init__(manif)
-        d = self.d
-        self.kmax = kmax
-
-        ar1_phi = 0.0 * torch.ones(d) if ar1_phi is None else ar1_phi
-        ar1_eta = torch.ones(d) if ar1_eta is None else torch.sqrt(ar1_eta)
-        ar1_c = torch.zeros(d) if ar1_c is None else ar1_c
-        self.ar1_phi = nn.Parameter(data=ar1_phi, requires_grad=True)
-        self.ar1_eta = nn.Parameter(data=ar1_eta, requires_grad=True)
-        self.ar1_c = nn.Parameter(data=ar1_c, requires_grad=True)
-
-    @property
-    def prms(self):
-        return self.ar1_c, self.ar1_phi, torch.square(self.ar1_eta)
-
-    def forward(self, g, ts=None):
-        ar1_c, ar1_phi, ar1_eta = self.prms
-        ginv = self.manif.inverse(g)
-        dg = self.manif.gmul(ginv[..., 0:-1, :], g[..., 1:, :])
-        dx = self.manif.logmap(dg)
-        dy = dx[..., 1:, :] - ((ar1_phi * dx[..., 0:-1, :]))
-        # dy = torch.cat((dx[..., 0:1, :], dy), -2)
-        normal = dists.Normal(loc=ar1_c, scale=torch.sqrt(ar1_eta))
-        diagn = dists.Independent(normal, 1)
-        lq = self.manif.log_q(diagn.log_prob, dy, self.manif.d, kmax=self.kmax)
-        #(n_b, m) -> (n_b)
-        return lq.sum(-1)
-
-    @property
-    def msg(self):
-        ar1_c, ar1_phi, ar1_eta = self.prms
-        return (' ar1_c {:.3f} | ar1_phi {:.3f} | ar1_eta {:.3f} |').format(
-            ar1_c.item(), ar1_phi.item(), ar1_eta.item())
-
-
 class ARP(Lprior):
     name = "ARP"
 
@@ -234,7 +191,8 @@ class ARP(Lprior):
                  ar_c=None,
                  learn_phi=True,
                  learn_eta=True,
-                 learn_c=True):
+                 learn_c=True,
+                diagonal = True):
         '''
         ..math::
           :nowrap:
@@ -247,6 +205,9 @@ class ARP(Lprior):
         d = self.d
         self.p = p
         self.kmax = kmax
+        if 'So3' in manif.name:
+            diagonal = False
+        self.diagonal = diagonal
 
         ar_phi = 0.0 * torch.ones(d, p) if ar_phi is None else ar_phi
         ar_eta = 0.05 * torch.ones(d) if ar_eta is None else ar_eta
@@ -265,21 +226,32 @@ class ARP(Lprior):
         ginv = self.manif.inverse(g)  # n_b x mx x d2 (on group)
         dg = self.manif.gmul(ginv[..., 0:-1, :],
                              g[..., 1:, :])  # n_b x (mx-1) x d2 (on group)
-        dx = self.manif.logmap(dg)  # n_b x (mx-1) x d2 (on algebra)
+        dx = self.manif.logmap(dg)  # n_b x (mx-1) x d (on algebra)
         delta = ar_phi * torch.stack(
             [dx[..., p - j - 1:-j - 1, :] for j in range(p)], dim=-1)
-        dy = dx[..., p:, :] - delta.sum(-1)  # n_b x (mx-1-p) x d2 (on group)
+        dy = dx[..., p:, :] - delta.sum(-1)  # n_b x (mx-1-p) x d (on alegbra)
 
         scale = torch.sqrt(ar_eta)
-        lq = torch.stack([
-            self.manif.log_q(dists.Normal(ar_c[j], scale[j]).log_prob,
-                             dy[..., j, None],
-                             1,
-                             kmax=self.kmax).sum(-1) for j in range(self.d)
-        ])  #(1 x n_b x m-p-1)
+        
+        if self.diagonal: #diagonal covariance
+            lq = torch.stack([
+                self.manif.log_q(dists.Normal(ar_c[j], scale[j]).log_prob,
+                                 dy[..., j, None],
+                                 1,
+                                 kmax=self.kmax).sum(-1) for j in range(self.d)
+            ])  #(d x n_b x m-p-1)
+            lq = lq.sum(0) #(n_b x m-p-1)
+        else: #not diagonal (e.g. SO(3))
+            normal = dists.Normal(loc=ar_c, scale=scale)
+            diagn = dists.Independent(normal, 1)
+            lq = self.manif.log_q(diagn.log_prob,
+                                    dy,
+                                    self.manif.d,
+                                    kmax=self.kmax)
+            # (n_b x m-p-1)
 
-        #print(lq.shape)
-        lq = lq.sum(0).sum(-1)
+
+        lq = lq.sum(-1)
 
         #in the future, we may want an explicit prior over the p initial points
         return lq
@@ -293,174 +265,3 @@ class ARP(Lprior):
             ar_eta.detach().cpu().sqrt().mean())
         return lp_msg
 
-
-class ARP_G(Lprior):
-    name = "ARP"
-
-    def __init__(self,
-                 p,
-                 manif: Manifold,
-                 kmax: int = 5,
-                 ar_phi=None,
-                 ar_eta=None,
-                 ar_c=None,
-                 learn_eta=True,
-                 learn_phi=True,
-                 learn_c=True):
-        '''
-        .. math::
-
-            \\tilde{g}_t &= g_c \\prod_{j=p}^1 \\exp(a_j \\log(g_t-j*g_{t-j-1})) g_{t-1}
-            \\text{Log}[ \\tilde{g}_t g_{t-1}^(-1) ] \\sim N(0, \\eta)
-        '''
-        super().__init__(manif)
-        d = self.d
-        self.p = p
-        self.kmax = kmax
-
-        #ar_phi = 1e-3 * torch.randn(d, p-1) if ar_phi is None else ar_phi
-        ar_phi = 1e-3 * torch.randn(1, p - 1) if ar_phi is None else ar_phi
-        #ar_eta = 0.5 * torch.ones(d) if ar_eta is None else ar_eta
-        ar_eta = torch.tensor(0.5) if ar_eta is None else ar_eta
-        ar_c = 1e-3 * torch.randn(d) if ar_c is None else ar_c
-
-        ### AR parameters
-        self.ar_phi = nn.Parameter(data=ar_phi, requires_grad=learn_phi)
-
-        #w_t \sim Exp[ N(0, eta) ]
-        self.ar_eta = nn.Parameter(data=ar_eta, requires_grad=learn_eta)
-
-        #parameterize as g_c = exp(x_c) for now
-        self.ar_c = nn.Parameter(data=ar_c, requires_grad=learn_c)
-
-    @property
-    def prms(self):
-        return self.ar_c, self.ar_phi, torch.square(self.ar_eta)
-
-    def forward(self, g: Tensor, ts=None):
-        '''
-        g is (n_b x mx x d2)
-        '''
-        p = self.p
-        _, mx, _ = g.shape
-
-        ar_c, ar_phi, ar_eta = self.prms
-        ginv = self.manif.inverse(g)  # n_b x mx x d2 (on group)
-
-        if p > 1:  #if p > 1 we need to consider past displacements
-            dg = self.manif.gmul(ginv[..., 0:-1, :],
-                                 g[..., 1:, :])  #n_b x (mx-1) x d (on group)
-
-            #f_i(dg) = 'a_i dg' = Exp[ a_i*Log[dg] ]
-            dx = self.manif.logmap(dg)  #n_b x (mx-1) x d (on algebra)
-            delta = ar_phi * torch.stack(
-                [dx[..., (p - j - 2):(mx - j - 2), :] for j in range(p - 1)],
-                dim=-1)  # n_b x (mx-p) x d x (p-1) (on algebra)
-            delta = delta.permute(0, 1, 3,
-                                  2)  # n_b x (mx-p) x (p-1) x d (on algebra)
-            dg_phi = self.manif.expmap(
-                delta)  #n_b x (mx-p) x (p-1) x d2 (on group)
-            #print(delta.shape, dg_phi.shape)
-
-        #consider g_{t-1} for t = (p+1:T)
-        g_tm1 = g[:, (p - 1):-1, :]  # n_b x (mx-p) x d2 (on group)
-
-        #sequentially apply group elements
-        g_pred = g_tm1  #n_b x (mx-p) x d2 (on group)
-
-        for i in range(1, p):
-            #sequential multiplication ... g_t-1 * dg_t-1 * ... * dg_t-p+1
-            g_pred = self.manif.gmul(
-                g_pred, dg_phi[:, :, -i, :])  #n_b x (mx-p) x d2 (on group)
-
-        #g_t-1 * dg_t-1 * ... * dg_t-p+1 * g_c
-        g_c = self.manif.expmap(ar_c.reshape(1, 1, -1))  #1 x 1 x d2 (on group)
-        g_pred = self.manif.gmul(
-            g_pred, g_c)  #n_b x (mx-p) x d2 (on group) -- add constant element
-
-        #g_t g_pred \approx I
-        #only consider timepoints we have sufficient data for
-        g_true = g[:, p:, :]  # n_b x (mx-p) x d2 (on group)
-        g_pred_inv = self.manif.inverse(g_pred)  #inverse prediction
-        #discrepancy between true and prediction
-        g_err = self.manif.gmul(g_true,
-                                g_pred_inv)  # n_b x (mx-p) x d2 (on group)
-
-        #compute an x_err s.t. Exp(x_err) = g_err
-        x_err = self.manif.logmap(g_err)  # n_b x (mx-p) x d (on group)
-
-        #likelihood of errors is given by a diagonal Gaussian projected onto the manifold
-        scale = torch.ones(self.manif.d) * torch.sqrt(ar_eta)
-
-        lq = torch.stack([
-            self.manif.log_q(dists.Normal(ar_c[j], scale[j]).log_prob,
-                             x_err[..., j, None],
-                             1,
-                             kmax=self.kmax).sum(-1) for j in range(self.d)
-        ]).sum(0)
-
-        #return sum over m -- probability of each trajectory
-        return lq
-
-    def generate_trajectory(self, m, g0s, noise=True):
-        '''
-        generate trajectory of length m drawn from the model.
-        must provide a 'seed' of initial states
-        g0 of dim p x d2
-        '''
-
-        ar_c, ar_phi, ar_eta = self.prms
-        p = self.p
-
-        gs = torch.zeros(m + p, g0s.shape[1])
-        gs[:p, :] = g0s
-
-        noise_dist = dists.Normal(loc=0,
-                                  scale=torch.ones(self.manif.d) *
-                                  torch.sqrt(ar_eta))
-        noises = noise_dist.sample((m + p, ))
-        if not noise:
-            noises *= 0
-
-        for t in range(p, m + p):
-
-            gprevs = gs[t - p:t, :]  #AR(p) -- need p most recent states
-            if p > 1:
-                ginv = self.manif.inverse(gprevs)  #p x d2
-                dg = self.manif.gmul(ginv[0:-1, :],
-                                     gprevs[1:, :])  #(p-1) x d2s
-                dx = self.manif.logmap(dg)  #(p-1) x d (on algebra)
-                #print(ar_phi.shape, dx.shape)
-                delta = ar_phi.T * dx  #(p-1) x d (on algebra)
-                dg_phi = self.manif.expmap(delta)  #(p-1) x d2 (on group)
-
-            #print('dg_phi', dg_phi.shape)
-            g_pred = gprevs[-1, :]  # d2 (on group)
-            #print('g_pred', g_pred.shape)
-            for i in range(1, p):
-                #sequential multiplication ... g_t-1 * dg_t-1 * ... * dg_t-p+1
-                g_pred = self.manif.gmul(g_pred, dg_phi[-i, :])  #d2 (on group)
-
-            #g_t-1 * dg_t-1 * ... * dg_t-p+1 * g_c
-            g_c = self.manif.expmap(ar_c)  # d2 (on group)
-            g_pred = self.manif.gmul(
-                g_pred, g_c)  # d2 (on group) -- add constant element
-            #print(g_c.shape, g_pred.shape)
-
-            x_pred = self.manif.logmap(g_pred)  # d (on algebra)
-            x_new = x_pred + noises[t, :]  # d (on algebra)
-            #print(x_pred.shape, x_new.shape)
-            g_new = self.manif.expmap(x_new)  #new state
-            #print(g_new.shape, gs.shape)
-            gs[t, :] = g_new
-
-        return gs
-
-    @property
-    def msg(self):
-        ar_c, ar_phi, ar_eta = self.prms
-        lp_msg = (' ar_c {:.3f} | ar_phi_avg {:.3f} | ar_eta {:.3f} |').format(
-            ar_c.item(),
-            torch.mean(ar_phi).item(),
-            ar_eta.sqrt().item())
-        return lp_msg

--- a/mgplvm/manifolds/quaternion.py
+++ b/mgplvm/manifolds/quaternion.py
@@ -2,7 +2,7 @@ import torch
 
 
 def conj(x):
-    a = torch.tensor([1, -1, -1, -1])
+    a = torch.tensor([1, -1, -1, -1]).to(x.device)
     return a * x
 
 

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -49,6 +49,9 @@ class So3(Manifold):
         #mudata = torch.tensor(np.array([[1, 0, 0, 0] for i in range(m)]), dtype=torch.get_default_dtype())
         return mudata
 
+    def parameterise_inducing(self, x):
+        return self.expmap2(x, dim = -2)
+    
     def inducing_points(self, n, n_z, z=None):
         if z is None:
             z = torch.randn(n, self.d2, n_z)
@@ -58,7 +61,8 @@ class So3(Manifold):
                               self.d2,
                               n_z,
                               z=z,
-                              parameterise=lambda x: self.expmap2(x, dim=-2))
+                              parameterise = self.parameterise_inducing)
+                              #parameterise=lambda x: self.expmap2(x, dim=-2))
 
     @property
     def name(self):

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -35,6 +35,7 @@ class Torus(Manifold):
             else:
                 pca = decomposition.PCA(n_components=d)
                 mudata = pca.fit_transform(Y[:, :, 0].T)  #m x d
+                #constrain to injectivity radius
                 mudata *= 2 * np.pi / (np.amax(mudata) - np.amin(mudata))
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())
         mudata = torch.randn(m, d) * 0.1

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -94,7 +94,7 @@ def generate_batch_idxs(model, data_size, batch_pool=None, batch_size=None):
         idxs = np.arange(data_size)
     else:
         idxs = copy.copy(batch_pool)
-    if model.lprior.name == "Brownian":
+    if model.lprior.name in ["Brownian", "ARP"]:
         # if prior is Brownian, then batches have to be contiguous
         i0 = np.random.randint(1, data_size - 1)
         if i0 < batch_size / 2:


### PR DESCRIPTION
Add PCA initialization for SO(3) (rescale PCA latents to the injectivity radius on the Lie algebra, project on to SO(3)).
Add diagonal/non-diagonal log probability calculations for AR(p) (needed for SO(3) and S(d)).
Remove ARP_G and AR(1) priors which we no longer use
Remove a lambda function from the SO(3) class since lambda functions are not pickleable which prevent model storage using torch.save(mod).
Add tests for AR(p) for all manifolds.
Make sure batches are continuous in fit() when using an AR(p) prior.