### PR TITLE
Minor clean-up of svgp sort_params function

### DIFF
--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -70,9 +70,9 @@ def generate_batch_idxs(model, data_size, batch_pool=None, batch_size=None):
     if batch_pool is None:
         idxs = np.arange(data_size)
     else:
-        idxs = copy.copy(batch_pool)
-    if model.lprior.name == "Brownian":
-        # if prior is Brownian, then batches have to be contiguous
+        idxs = batch_pool
+    if model.lprior.name in ["Brownian", "ARP"]:
+        # if prior is Brownian or ARP, then batches have to be contiguous
         i0 = np.random.randint(1, data_size - 1)
         if i0 < batch_size / 2:
             batch_idxs = idxs[:int(round(batch_size / 2 + i0))]
@@ -83,15 +83,11 @@ def generate_batch_idxs(model, data_size, batch_pool=None, batch_size=None):
                                         2)):int(round(i0 + batch_size / 2))]
         #print(len(batch_idxs))
         return batch_idxs
-
-        #start = np.random.randint(data_size - batch_size)
-        #return idxs[start:start + batch_size]
     else:
         if batch_size is None:
             return idxs
         else:
-            np.random.shuffle(idxs)
-            return idxs[0:batch_size]
+            return np.random.choice(idxs, size = batch_size, replace = False)
 
 
 def fit(Y,

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -8,11 +8,33 @@ import torch
 from torch import optim, Tensor
 from torch.optim.lr_scheduler import LambdaLR
 from typing import List
+import itertools
 
 
 def sort_params(model, hook):
     '''apply burnin period to Sigma_Q and alpha^2
     allow for masking of certain conditions for use in crossvalidation'''
+
+    for prm in model.lat_dist.parameters():
+        prm.register_hook(hook)
+
+    params0 = list(
+        itertools.chain.from_iterable([
+            model.z.parameters(),
+            model.likelihood.parameters(),
+            model.lprior.parameters(),
+            model.lat_dist.gmu_parameters(),
+            [model.svgp.q_mu, model.svgp.q_sqrt],
+        ]))
+
+    params1 = list(
+        itertools.chain.from_iterable([
+            model.kernel.parameters(),
+            #model.lat_dist.concentration_parameters()
+        ]))
+
+    params = [params0, params1]
+    return params
 
     # parameters to be optimized
     lat_params = list(model.lat_dist.parameters())

--- a/mgplvm/rdist/common.py
+++ b/mgplvm/rdist/common.py
@@ -27,3 +27,11 @@ class Rdist(Module, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sample(self, size, Y, batch_idxs, kmax) -> Tuple[Tensor, Tensor]:
         pass
+
+    @abc.abstractmethod
+    def gmu_parameters(self):
+        pass
+
+    @abc.abstractmethod
+    def concentration_parameters(self):
+        pass

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -28,7 +28,7 @@ class ReLieBase(Rdist):
         return gmu, gamma
 
     def lat_gmu(self, Y=None, batch_idxs=None):
-        return self.lat_prms(Y)[0]
+        return self.lat_prms(Y, batch_idxs)[0]
 
     def lat_gamma(self, Y=None, batch_idxs=None):
         return self.lat_prms(Y, batch_idxs)[1]

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -14,7 +14,11 @@ from ..base import Module
 class ReLieBase(Rdist):
     name = "ReLieBase"
 
-    def __init__(self, manif: Manifold, f, kmax: int = 5, diagonal: bool = False):
+    def __init__(self,
+                 manif: Manifold,
+                 f,
+                 kmax: int = 5,
+                 diagonal: bool = False):
         super(ReLieBase, self).__init__(manif, kmax)
         self.f = f
         self.diagonal = diagonal
@@ -49,20 +53,26 @@ class ReLieBase(Rdist):
         x = q.rsample(size)
         m = x.shape[1]
         mu = torch.zeros(m).to(gamma.device)[..., None]
-        if self.diagonal: #compute diagonal covariance
+        if self.diagonal:  #compute diagonal covariance
             lq = torch.stack([
                 self.manif.log_q(
                     Normal(mu, gamma[..., j, j][..., None]).log_prob,
                     x[..., j, None], 1, self.kmax).sum(dim=-1)
                 for j in range(self.d)
             ]).sum(dim=0)
-        else: #compute entropy with full covariance matrix
+        else:  #compute entropy with full covariance matrix
             lq = self.manif.log_q(q.log_prob, x, self.manif.d, self.kmax)
-        
+
         gtilde = self.manif.expmap(x)
         # apply g_mu with dims: (n_mc x m x d)
         g = self.manif.gmul(gmu, gtilde)
         return g, lq
+
+    def gmu_parameters(self):
+        return self.f.gmu_parameters()
+
+    def concentration_parameters(self):
+        return self.f.concentration_parameters()
 
 
 class _F(Module):
@@ -74,14 +84,14 @@ class _F(Module):
                  gamma: Optional[Tensor] = None,
                  fixed_gamma=False,
                  diagonal=False,
-                 mu = None,
+                 mu=None,
                  initialization: Optional[str] = 'random',
                  Y=None):
 
         super(_F, self).__init__()
         self.manif = manif
         self.diagonal = diagonal
-        
+
         if mu is None:
             gmu = self.manif.initialize(initialization, m, manif.d, Y)
         else:
@@ -96,8 +106,8 @@ class _F(Module):
         else:
             gamma = torch.diag_embed(gamma)
             gamma = transform_to(constraints.lower_cholesky).inv(gamma)
-            
-        self.gamma = nn.Parameter(data=gamma, requires_grad= (not fixed_gamma))
+
+        self.gamma = nn.Parameter(data=gamma, requires_grad=(not fixed_gamma))
 
     def forward(self, Y=None, batch_idxs=None):
         gmu, gamma = self.prms
@@ -116,6 +126,12 @@ class _F(Module):
                 MultivariateNormal.arg_constraints['scale_tril'])(self.gamma)
         return gmu, gamma
 
+    def gmu_parameters(self):
+        return [self.gmu]
+
+    def concentration_parameters(self):
+        return [self.gamma]
+
 
 class ReLie(ReLieBase):
     name = "ReLie"
@@ -128,7 +144,7 @@ class ReLie(ReLieBase):
                  gamma: Optional[Tensor] = None,
                  fixed_gamma=False,
                  diagonal=False,
-                 mu = None,
+                 mu=None,
                  initialization: Optional[str] = 'random',
                  Y=None):
         """


### PR DESCRIPTION
- Instead of looping through the parameters and separating them into groups, we now directly separate them based on their parent module. 
-  to effectively single out "concentration" parameters in the latent distribution, I added two methods `gmu_parameters` and `concentration_parameters` to the `Rdist` class.