### PR TITLE
Removing n_samples dimension

### DIFF
--- a/mgplvm/kernels.py
+++ b/mgplvm/kernels.py
@@ -90,8 +90,7 @@ class QuadExpBase(Kernel):
             alpha = inv_softplus(
                 torch.tensor(alpha, dtype=torch.get_default_dtype()))
         elif Y is not None:
-            alpha = inv_softplus(
-                torch.tensor(np.mean(Y[:, :, 0]**2, axis=1)).sqrt())
+            alpha = inv_softplus(torch.tensor(np.mean(Y**2, axis=-1)).sqrt())
         else:
             alpha = inv_softplus(torch.ones(n, ))
 

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -64,42 +64,34 @@ class Gaussian(Likelihood):
         y_samps = dist.sample()
         return y_samps
 
-    def variational_expectation(self, n_samples, y, fmu, fvar):
+    def variational_expectation(self, y, fmu, fvar):
         """
         Parameters
         ----------
-        n_samples : int
-            number of samples
         y : Tensor
-            number of MC samples (n x m x n_samples)
+            number of MC samples (n x m)
         f_mu : Tensor
-            GP mean (n_mc x n x m x n_samples)
+            GP mean (n_mc x n x m)
         f_var : Tensor
             GP diagonal variance (n_mc x n x m)
 
         Returns
         -------
         Log likelihood : Tensor
-            SVGP likelihood term per MC, neuron, sample (n_mc x n x n_samples)
+            SVGP likelihood term per MC, neuron, sample (n_mc x n)
         """
         n_mc, m = fmu.shape[0], fmu.shape[2]
         variance = self.prms  #(n)
         #print(variance.shape)
         ve1 = -0.5 * log2pi * m  #scalar
         ve2 = -0.5 * torch.log(variance) * m  #(n)
-        ve3 = -0.5 * torch.square(y - fmu) / variance[
-            ..., None, None]  #(n_mc x n x m x n_samples)
+        ve3 = -0.5 * torch.square(y - fmu) / variance[...,
+                                                      None]  #(n_mc x n x m )
         ve4 = -0.5 * fvar / variance[..., None]  #(n_mc x n x m)
 
         #print(ve1.shape, ve2.shape, ve3.shape, ve4.shape)
-        exp = ve1 + ve2[None, ..., None] + ve3.sum(-2) + ve4.sum(-1)[..., None]
-        #(n_mc x n x n_samples)
-        #print(exp.shape)
-        '''
-        else:
-            exp = ve1.sum() + ve2.sum() + ve3.sum() + ve4.sum()
-        '''
-        return exp
+        #(n_mc x n)
+        return ve1 + ve2 + ve3.sum(-1) + ve4.sum(-1)
 
 
 class Poisson(Likelihood):
@@ -130,8 +122,8 @@ class Poisson(Likelihood):
             p = dists.Poisson(lamb)
             return p.log_prob(y)
         else:
-            #lambd: (n_mc, n, m, n_samples, n_gh)
-            #y: (n, m, n_samples)
+            #lambd: (n_mc, n, m, n_gh)
+            #y: (n, m)
             p = dists.Poisson(lamb)
             return p.log_prob(y[None, ..., None])
 
@@ -154,22 +146,14 @@ class Poisson(Likelihood):
         y_samps = dist.sample()
         return y_samps
 
-    def variational_expectation(self,
-                                n_samples,
-                                y,
-                                fmu,
-                                fvar,
-                                gh=False,
-                                by_sample=False):
+    def variational_expectation(self, y, fmu, fvar, gh=False, by_sample=False):
         """
         Parameters
         ----------
-        n_samples : int
-            number of samples
         y : Tensor
-            number of MC samples (n x m x n_samples)
+            number of MC samples (n x m)
         f_mu : Tensor
-            GP mean (n_mc x n x m x n_samples)
+            GP mean (n_mc x n x m)
         f_var : Tensor
             GP diagonal variance (n_mc x n x m)
         gh [optional] : int
@@ -178,18 +162,17 @@ class Poisson(Likelihood):
         Returns
         -------
         Log likelihood : Tensor
-            SVGP likelihood term per MC, neuron, sample (n_mc x n x n_samples)
+            SVGP likelihood term per MC, neuron, sample (n_mc x n)
         """
         c, d = self.prms
-        fmu = c[..., None, None] * fmu + d[..., None, None]
+        fmu = c[..., None] * fmu + d[..., None]
         fvar = fvar * torch.square(c[..., None])
         #if self.inv_link == torch.exp and (not gh):
         if self.inv_link == 'exp' and (not gh):
             n_mc = fmu.shape[0]
-            v1 = (y * fmu) - (self.binsize *
-                              torch.exp(fmu + 0.5 * fvar[..., None]))
+            v1 = (y * fmu) - (self.binsize * torch.exp(fmu + 0.5 * fvar))
             v2 = (y * np.log(self.binsize) - torch.lgamma(y + 1))
-            #v1: (n_b x n x m x n_samples)  v2: (n x m x n_samples) (per mc sample)
+            #v1: (n_b x n x m)  v2: (n x m) (per mc sample)
             return v1.sum(-2) + v2.sum(-2)[None, ...]
 
         else:
@@ -197,13 +180,12 @@ class Poisson(Likelihood):
             locs, ws = np.polynomial.hermite.hermgauss(self.n_gh_locs)
             ws = torch.Tensor(ws).to(fmu.device)
             locs = torch.Tensor(locs).to(fvar.device)
-            fvar = fvar[..., None, None]  #add n_samples, n_gh
+            fvar = fvar[..., None]  #add n_gh
             fmu = fmu[..., None]  #add n_gh
-            locs = self.inv_link(
-                torch.sqrt(2. * fvar) * locs +
-                fmu) * self.binsize  #(n_mc, n, m, n_samples, n_gh)
+            locs = self.inv_link(torch.sqrt(2. * fvar) * locs +
+                                 fmu) * self.binsize  #(n_mc, n, m, n_gh)
             lp = self.log_prob(locs, y)
-            return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-2)
+            return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-1)
             #return torch.sum(1 / np.sqrt(np.pi) * lp * ws)
 
 
@@ -243,47 +225,43 @@ class NegativeBinomial(Likelihood):
     def sample(self, f_samps):
         '''f_samps is n_b x n x m'''
         total_count, c, d = self.prms
-        rate = c[None, ..., None] * f_samps + d[None, ..., None]  #shift+scale
+        rate = c[None, ...] * f_samps + d[None, ...]  #shift+scale
         rate = self.inv_link(rate) * self.binsize
-        dist = dists.NegativeBinomial(total_count[None, ..., None],
+        dist = dists.NegativeBinomial(total_count[None, ...],
                                       logits=rate)  #neg binom
         y_samps = dist.sample()  #sample observations
         return y_samps
 
     def log_prob(self, total_count, rate, y):
         if False:  #y.shape[-1] == 1:
-            p = dists.NegativeBinomial(total_count[..., None, None],
-                                       logits=rate)
+            p = dists.NegativeBinomial(total_count[..., None], logits=rate)
             return p.log_prob(y)
         else:
-            #total count: (n) -> (n_mc, n, m, n_samples, n_gh)
-            #rate: (n_mc, n, m, n_samples, n_gh)
-            #y: (n, m, n_samples)
-            p = dists.NegativeBinomial(
-                total_count[None, ..., None, None, None], logits=rate)
+            #total count: (n) -> (n_mc, n, m, n_gh)
+            #rate: (n_mc, n, m, n_gh)
+            #y: (n, m)
+            p = dists.NegativeBinomial(total_count[None, ..., None, None],
+                                       logits=rate)
             return p.log_prob(y[None, ..., None])
 
-    def variational_expectation(self, n_samples, y, fmu, fvar,
-                                by_sample=False):
+    def variational_expectation(self, y, fmu, fvar, by_sample=False):
         """
         Parameters
         ----------
-        n_samples : int
-            number of samples
         y : Tensor
-            number of MC samples (n x m x n_samples)
+            number of MC samples (n x m)
         f_mu : Tensor
-            GP mean (n_mc x n x m x n_samples)
+            GP mean (n_mc x n x m)
         f_var : Tensor
             GP diagonal variance (n_mc x n x m)
 
         Returns
         -------
         Log likelihood : Tensor
-            SVGP likelihood term per MC, neuron, sample (n_mc x n x n_samples)
+            SVGP likelihood term per MC, neuron, sample (n_mc x n)
         """
         total_count, c, d = self.prms
-        fmu = c[..., None, None] * fmu + d[..., None, None]
+        fmu = c[..., None] * fmu + d[..., None]
         fvar = fvar * torch.square(c[..., None])
         #print(fmu.shape, fvar.shape)
         # use Gauss-Hermite quadrature to approximate integral
@@ -291,17 +269,16 @@ class NegativeBinomial(Likelihood):
             self.n_gh_locs)  #sample points and weights for quadrature
         ws = torch.Tensor(ws).to(fmu.device)
         locs = torch.Tensor(locs).to(fvar.device)
-        fvar = fvar[..., None, None]  #add n_samples and locs
+        fvar = fvar[..., None]  #add n_samples and locs
         fmu = fmu[..., None]  #add locs
         #print(locs.shape)
         locs = self.inv_link(torch.sqrt(2. * fvar) * locs +
                              fmu) * self.binsize  #coordinate transform
         #print(total_count.shape, locs.shape)
-        lp = self.log_prob(total_count, locs,
-                           y)  #(n_mc x n x m x n_samples, n_gh)
+        lp = self.log_prob(total_count, locs, y)  #(n_mc x n x m, n_gh)
 
         #print(lp.shape, ws.shape, (lp * ws).shape)
-        return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-2)
+        return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-1)
 
         #else:
         #    return torch.sum(1 / np.sqrt(np.pi) * lp * ws)

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -56,23 +56,13 @@ class GP(LpriorEuclid):
         x is a latent of shape (n_mc x mx x d)
         ts is the corresponding timepoints of shape (mx)
         '''
-        #elbo(n_sample, n_mc, y, x)
-        #x is (n_mc x d x mx)
-        #y is (n x mx x n_samples)
+        n_mc, T, d = x.shape
+        # x now has shape (n_mc times d, mx)
+        x = x.transpose(-1, -2).reshape(-1, T)
 
-        #ts is (1 x 1 x mx)
-        #x is (d x mx x n_samples)
-
-        #elbo returns svgp_lik, svgp_kl
-        #LLs = [self.svgp.elbo(1, x[i, :, :, None].permute(1,0,2), ts.reshape(1,1,-1)) for i in range(x.shape[0])]
-        #LLs = torch.stack([LL[0] - LL[1] for LL in LLs], dim = 0)
-
-        svgp_elbo = self.svgp.elbo(x.shape[0], x.permute(2, 1, 0),
-                                   ts.reshape(1, 1, -1))
-
-        #shape: (1 x d x n_mc)
-
-        return svgp_elbo.sum(0).sum(0)
+        # shape (n_mc . d)
+        svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, 1, -1))
+        return svgp_elbo.reshape(n_mc, d).sum(-1)
 
     @property
     def msg(self):

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -71,7 +71,6 @@ class GP(LpriorEuclid):
                                    ts.reshape(1, 1, -1))
 
         #shape: (1 x d x n_mc)
-        #print(svgp_elbo.shape, svgp_elbo.device)
 
         return svgp_elbo.sum(0).sum(0)
 

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -141,9 +141,10 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         query = torch.unsqueeze(query.T, 0)  #add batch dimension
 
-        mu, v = self.predict(query, False)  #1xnxmx1, 1xnxm
-        mu = mu[0, :, :, 0]  #n x m,
-        v = v[0, :, :]  # nxm
+        mu, v = self.predict(query, False)  #1xnxm, 1xnxm
+        # remove batch dimension
+        mu = mu[0]  #n x m,
+        v = v[0]  # nxm
 
         #sample from p(f|u)
         dist = Normal(mu, torch.sqrt(v))

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -87,7 +87,7 @@ def generate_batch_idxs(model, data_size, batch_pool=None, batch_size=None):
         if batch_size is None:
             return idxs
         else:
-            return np.random.choice(idxs, size = batch_size, replace = False)
+            return np.random.choice(idxs, size=batch_size, replace=False)
 
 
 def fit(Y,
@@ -117,7 +117,10 @@ def fit(Y,
     def fburn(x):
         return 1 - np.exp(-x / (3 * burnin))
 
-    n, m, _ = Y.shape  # neurons, conditions, samples
+    if len(Y.shape) > 2:
+        _, n, m = Y.shape  # samples, neurons, conditions
+    else:
+        n, m = Y.shape  # neuron x conditions
     data = torch.tensor(Y, dtype=torch.get_default_dtype()).to(device)
     ts = ts if ts is None else ts.to(device)
     data_size = m if batch_pool is None else len(batch_pool)  #total conditions

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -162,7 +162,7 @@ class ReLie(ReLieBase):
         mu : Optional[np.ndarray]
             initialization of the vartiational means (m x d2)
         Y : Optional[np.ndarray]
-            data used to initialize latents (n x m x n_samples)
+            data used to initialize latents (n x m)
             
         Notes
         -----

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -27,7 +27,7 @@ def test_so3_dimensions():
 
 def test_manifs_runs():
     m, d, n, n_z = 10, 3, 5, 5
-    Y = np.random.normal(0, 1, (n, m, 1))
+    Y = np.random.normal(0, 1, (n, m))
     for i, manif_type in enumerate(
         [manifolds.Torus, manifolds.So3, manifolds.S3]):
         manif = manif_type(m, d)
@@ -64,4 +64,3 @@ if __name__ == '__main__':
     test_torus_dimensions()
     test_so3_dimensions()
     test_manifs_runs()
-    print('Tested manifolds')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,16 +26,16 @@ def test_svgp_runs():
     sig0 = 1.5
     l = 0.4
     gen.set_param('l', l)
-    Y = gen.gen_data()
+    Y = gen.gen_data()[0]
     Y = Y + np.random.normal(size=Y.shape) * np.mean(Y) / 3
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
     lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=sig0, diagonal=False)
     # initialize signal variance
-    alpha = np.mean(np.std(Y, axis=1), axis=1)
+    alpha = np.std(Y, axis=1)
     kernel = kernels.QuadExp(n, manif.distance, alpha=alpha)
     # generate model
-    sigma = np.mean(np.std(Y, axis=1), axis=1)  # initialize noise
+    sigma = np.std(Y, axis=1)  # initialize noise
     lik = likelihoods.Gaussian(n, variance=np.square(sigma))
     lprior = mgplvm.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
@@ -52,15 +52,14 @@ def test_svgp_runs():
                                         n_mc=64,
                                         lrate=2E-2,
                                         print_every=1000)
-    
-    
+
     ### test burda log likelihood ###
     LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
     svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
-    elbo = (svgp_elbo-kl)/(Y.shape[0]*Y.shape[1])
-    
+    elbo = (svgp_elbo - kl) / (Y.shape[0] * Y.shape[1])
+
     assert elbo < LL
-    
+
 
 if __name__ == '__main__':
     test_svgp_runs()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,4 +63,3 @@ def test_svgp_runs():
 
 if __name__ == '__main__':
     test_svgp_runs()
-    print('Tested models')

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -74,15 +74,16 @@ def test_GP_prior():
 
     #### naive computation ####
     LLs1 = [
-        mod.lprior.svgp.elbo(1, x[i, :, :, None].permute(1, 0, 2),
-                             ts.reshape(1, 1, -1)) for i in range(x.shape[0])
+        mod.lprior.svgp.elbo(1, x[i].transpose(-1, -2), ts.reshape(1, 1, -1))
+        for i in range(x.shape[0])
     ]
     elbo1_b = torch.stack([LL.sum() for LL in LLs1], dim=0)
 
     #### try to batch things ####
-    elbo2_b = mod.lprior.svgp.elbo(x.shape[0], x.permute(2, 1, 0),
+    elbo2_b = mod.lprior.svgp.elbo(1,
+                                   x.transpose(-1, -2).reshape(-1, m),
                                    ts.reshape(1, 1, -1))
-    elbo2_b = elbo2_b.sum(0).sum(0)
+    elbo2_b = elbo2_b.reshape(n_mc, d).sum(-1)
     print(elbo1_b.shape, elbo2_b.shape)
 
     ### print comparison ###

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -24,19 +24,19 @@ def test_GP_prior():
                              sigma=0.8,
                              beta=0.1)
     sig0 = 1.5
-    Y = gen.gen_data(ell=25, sig=1)
-
+    Y = gen.gen_data(ell=25, sig=1)[0]
     # specify manifold, kernel and rdist
     manif = mgplvm.manifolds.Euclid(m, d)
+    alpha = np.std(Y, axis=1)
+    sigma = np.std(Y, axis=1)  # initialize noise
+    kernel = mgplvm.kernels.QuadExp(n, manif.distance, alpha=alpha)
 
     #lat_dist = mgplvm.rdist.MVN(m, d, sigma=sig0)
     lat_dist = mgplvm.rdist.ReLie(manif,
                                   m,
                                   sigma=sig0,
                                   initialization='random',
-                                  Y=Y[:, :, 0])
-    alpha = np.mean(np.std(Y, axis=1), axis=1)
-    kernel = mgplvm.kernels.QuadExp(n, manif.distance, alpha=alpha)
+                                  Y=Y)
 
     ###construct prior
     lprior_kernel = mgplvm.kernels.QuadExp(d,
@@ -46,7 +46,6 @@ def test_GP_prior():
     #lprior = lpriors.Gaussian(manif)
 
     # generate model
-    sigma = np.mean(np.std(Y, axis=1), axis=1)  # initialize noise
     likelihood = mgplvm.likelihoods.Gaussian(n, variance=np.square(sigma))
     z = manif.inducing_points(n, n_z)
     mod = mgplvm.models.SvgpLvm(n, z, kernel, likelihood, lat_dist,
@@ -69,7 +68,6 @@ def test_GP_prior():
     ### test that two ways of computing the prior agree ###
     data = torch.tensor(Y).to(device)
     ts = torch.arange(m).to(device)
-    _, _, n_samples = data.shape  #n x mx x n_samples
     g, lq = mod.lat_dist.sample(torch.Size([n_mc]), data, None)
 
     x = g  #input to prior
@@ -94,21 +92,22 @@ def test_GP_prior():
     print(elbo1_b[:5])
     print(elbo2_b[:5])
 
+
 def test_ARP_runs():
     m, d, n, n_z, p = 10, 3, 5, 5, 1
-    Y = np.random.normal(0, 1, (n, m, 1))
+    Y = np.random.normal(0, 1, (n, m))
     for i, manif_type in enumerate(
         [manifolds.Euclid, manifolds.Torus, manifolds.So3]):
         manif = manif_type(m, d)
         print(manif.name)
-        lat_dist = mgplvm.rdist.ReLie(manif,
-                                      m,
-                                      sigma=0.4,
-                                      diagonal=(True if i in [0,1] else False))
+        lat_dist = mgplvm.rdist.ReLie(
+            manif, m, sigma=0.4, diagonal=(True if i in [0, 1] else False))
         kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y=Y)
         # generate model
         lik = mgplvm.likelihoods.Gaussian(n)
-        lprior = mgplvm.lpriors.ARP(p, manif, diagonal=(True if i in [0,1] else False))
+        lprior = mgplvm.lpriors.ARP(p,
+                                    manif,
+                                    diagonal=(True if i in [0, 1] else False))
         z = manif.inducing_points(n, n_z)
         mod = mgplvm.models.SvgpLvm(n,
                                     z,
@@ -126,7 +125,7 @@ def test_ARP_runs():
                                             n_mc=64,
                                             optimizer=optim.Adam,
                                             print_every=1000)
-    
+
 
 if __name__ == '__main__':
     test_GP_prior()

--- a/tests/test_syndata.py
+++ b/tests/test_syndata.py
@@ -1,0 +1,22 @@
+import mgplvm as mgp
+
+
+def test_data_shapes():
+    n = 100
+    m = 20
+    n_samples = 10
+    d = 5
+    for d, manif in [
+        (d, mgp.syndata.Euclid(d)),
+        (d, mgp.syndata.Torus(d)),
+        (d + 1, mgp.syndata.Sphere(d)),
+        (4, mgp.syndata.So3()),
+    ]:
+        gen = mgp.syndata.Gen(manif, n, m, n_samples=n_samples)
+        Y = gen.gen_data()
+        assert (Y.shape == (n_samples, n, m))
+        assert (gen.gs[0].shape == (n_samples, m, d))
+
+
+if __name__ == "__main__":
+    test_data_shapes()


### PR DESCRIPTION
In this PR, I've removed the `n_samples` dimension from the data with an eye of adding them back in later. Currently, `Y` has dimensions `n x m x n_samples`. In this PR, I've removed the last dimensions as it is not currently being used, except in the GP prior (I fixed this as well).

In the future, we will most likely want to have `Y` with dimensions `n_samples x n x m` or `n x m` to deal with trial-structured data. Correspondingly we will have latents with dimensions `n_samples x d x m`. I'll leave this for a future PR.

Currently all the tests pass, but that is most likely because we don't have tests for the other likelihoods (e.g., Poisson and NegBinom). It would be good to add those tests before merging this PR. @KrisJensen @davindicode do you have existing code that uses these two likelihoods, which can be used to test the likelihoods run?

In this PR, I've also changed `syndata` such that its output has dimensions `n_samples x n x m` and latents `gs` with dimensions `n_samples x m x d`. To test these shapes, I've added `test_syndata.py`. 