### PR TITLE
Added back n_samples dimension

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -6,10 +6,10 @@ import pickle
 import numpy as np
 
 
-def model_params(n, m, d, n_z, **kwargs):
+def model_params(n, m, d, n_z, n_samples, **kwargs):
     
     params = {
-        'n': n, 'm': m, 'd': d, 'n_z': n_z,
+        'n': n, 'm': m, 'd': d, 'n_z': n_z, 'n_samples': n_samples,
         'manifold': 'euclid',
         'kernel': 'RBF',
         'prior': 'Uniform',
@@ -42,7 +42,7 @@ def load_model(params):
 
     likelihoods = {'GP': lpriors.GP}
     
-    n, m, d, n_z = params['n'], params['m'], params['d'], params['n_z']
+    n, m, d, n_z, n_samples = params['n'], params['m'], params['d'], params['n_z'], params['n_samples']
     
     #### specify manifold ####
     if params['manifold'] == 'euclid':
@@ -54,7 +54,7 @@ def load_model(params):
         params['diagonal'] = False
         
     #### specify latent distribution ####
-    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=params['latent_sigma'], diagonal = params['diagonal'],
+    lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, sigma=params['latent_sigma'], diagonal = params['diagonal'],
                                  initialization = params['initialization'], Y = params['Y'],
                                  mu = params['latent_mu'])
     

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -70,7 +70,7 @@ def train_cv(mod,
     
     train_ps1 = update_params(train_ps, batch_pool = T1)
     
-    print(Y.shape, mod.lat_dist.prms[0].shape, mod.lat_dist.prms[1].shape)
+    #print(Y.shape, mod.lat_dist.prms[0].shape, mod.lat_dist.prms[1].shape)
     
     _ = train_model(mod, Y, device, train_ps1)
     

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -66,10 +66,12 @@ def train_cv(mod,
         T1 = np.random.permutation(np.arange(m))[:nt_train]
     if N1 is None: # random shuffle of neurons
         N1 = np.random.permutation(np.arange(n))[:nn_train]
-    Y1, Y2 = Y[:, :, T1], Y[:, N1, :]
     split = {'Y': Y, 'N1': N1, 'T1': T1}
     
     train_ps1 = update_params(train_ps, batch_pool = T1)
+    
+    print(Y.shape, mod.lat_dist.prms[0].shape, mod.lat_dist.prms[1].shape)
+    
     _ = train_model(mod, Y, device, train_ps1)
     
     ### construct a mask for some of the time points ####
@@ -106,7 +108,7 @@ def test_cv(mod, split, device, n_mc = 32, Print = False):
     latents = mod.lat_dist.prms[0].detach()[:, T2, ...] #latent means (ntrial, T2, d)
     query = latents.transpose(-1,-2) #(ntrial, d, m)
     Ypred, var = mod.svgp.predict(query[None, ...], False)
-    Ypred = Ypred.detach().cpu().numpy()[0, :, N2, :] #(ntrial, N2, T2)
+    Ypred = Ypred.detach().cpu().numpy()[0][:, N2, :] #(ntrial, N2, T2)
     MSE = np.mean((Ypred - Ytest)**2)
     
     var_cap = 1-np.var(Ytest - Ypred)/np.var(Ytest)

--- a/mgplvm/kernels.py
+++ b/mgplvm/kernels.py
@@ -90,7 +90,8 @@ class QuadExpBase(Kernel):
             alpha = inv_softplus(
                 torch.tensor(alpha, dtype=torch.get_default_dtype()))
         elif Y is not None:
-            alpha = inv_softplus(torch.tensor(np.mean(Y**2, axis=-1)).sqrt())
+            alpha = inv_softplus(
+                torch.tensor(np.mean(np.mean(Y**2, axis=-1), axis=0)).sqrt())
         else:
             alpha = inv_softplus(torch.ones(n, ))
 

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -53,16 +53,16 @@ class GP(LpriorEuclid):
 
     def forward(self, x, ts):
         '''
-        x is a latent of shape (n_mc x mx x d)
-        ts is the corresponding timepoints of shape (mx)
+        x is a latent of shape (n_mc x n_samples x mx x d)
+        ts is the corresponding timepoints of shape (n_samples x mx)
         '''
-        n_mc, T, d = x.shape
-        # x now has shape (n_mc times d, mx)
-        x = x.transpose(-1, -2).reshape(-1, T)
+        n_mc, n_samples, T, d = x.shape
+        # x now has shape (n_samples, n_mc, d, mx)
+        x = x.permute(1, 0, 3, 2).reshape(n_samples, -1, T)
 
-        # shape (n_mc . d)
-        svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, 1, -1))
-        return svgp_elbo.reshape(n_mc, d).sum(-1)
+        # shape (n_samples, n_mc . d)
+        svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, n_samples, 1, -1))
+        return svgp_elbo.reshape(n_samples, n_mc, d).sum(-1).T
 
     @property
     def msg(self):

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -46,7 +46,7 @@ class Euclid(Manifold):
         return InducingPoints(n, self.d, n_z, z=z)
 
     def lprior(self, g):
-        '''need empirical data here. g is (n_b x m x d)'''
+        '''need empirical data here. g is (n_b x n_samples x m x d)'''
         ps = -0.5 * torch.square(g) - 0.5 * np.log(2 * np.pi)
         return ps.sum(2)  # sum over d
 

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -24,17 +24,19 @@ class Euclid(Manifold):
 
     @staticmethod
     def initialize(initialization, n_samples, m, d, Y):
-        '''initializes latents - can add more exciting initializations as well'''
+        '''initializes latents - can add more exciting initializations as well
+        Y is (n_samples x n x m)'''
         if initialization == 'pca':
             #Y is n_samples x n x m; reduce to n_samples x m x d
             if Y is None:
                 print('user must provide data for PCA initialization')
             else:
+                n = Y.shape[1]
                 pca = decomposition.PCA(n_components=d)
-                Y = Y.reshape(-1, m)
-                mudata = pca.fit_transform(Y)  #m x d
-                mudata = mudata / np.std(mudata, axis=0, keepdims=True)
-                mudata = mudata.reshape(Y.shape[0], Y.shape[-1], -1)
+                Y = Y.transpose(1, 2).reshape(n_samples*m, n)
+                mudata = pca.fit_transform(Y)  #m*n_samples x d
+                mudata = mudata / np.std(mudata, axis=0, keepdims=True) #normalize
+                mudata = mudata.reshape(n_samples, m, d)
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())
         # default initialization
         mudata = torch.randn(n_samples, m, d) * 0.1

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -33,7 +33,7 @@ class Euclid(Manifold):
             else:
                 n = Y.shape[1]
                 pca = decomposition.PCA(n_components=d)
-                Y = Y.transpose(1, 2).reshape(n_samples*m, n)
+                Y = Y.transpose(0, 2, 1).reshape(n_samples*m, n)
                 mudata = pca.fit_transform(Y)  #m*n_samples x d
                 mudata = mudata / np.std(mudata, axis=0, keepdims=True) #normalize
                 mudata = mudata.reshape(n_samples, m, d)

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -21,21 +21,23 @@ class Euclid(Manifold):
         super().__init__(d)
         self.m = m
         self.d2 = d  # dimensionality of the group parameterization
-        
+
     @staticmethod
-    def initialize(initialization, m, d, Y):
+    def initialize(initialization, n_samples, m, d, Y):
         '''initializes latents - can add more exciting initializations as well'''
         if initialization == 'pca':
-            #Y is N x m; reduce to m x d
+            #Y is n_samples x n x m; reduce to n_samples x m x d
             if Y is None:
                 print('user must provide data for PCA initialization')
             else:
                 pca = decomposition.PCA(n_components=d)
-                mudata = pca.fit_transform(Y[:, :, 0].T)  #m x d
+                Y = Y.reshape(-1, m)
+                mudata = pca.fit_transform(Y)  #m x d
                 mudata = mudata / np.std(mudata, axis=0, keepdims=True)
+                mudata = mudata.reshape(Y.shape[0], Y.shape[-1], -1)
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())
         # default initialization
-        mudata = torch.randn(m, d) * 0.1
+        mudata = torch.randn(n_samples, m, d) * 0.1
         return mudata
 
     def inducing_points(self, n, n_z, z=None):

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -106,7 +106,7 @@ class S3(Manifold):
         zs = np.stack([z.flatten() for z in zs
                        ]).T * 2 * np.pi  #need to add multiples of 2pi
         zs = torch.tensor(zs, dtype=torch.get_default_dtype()).to(theta.device)
-        theta = theta + zs[:, None, None, ...]  # (nk, n_b, m, 1)
+        theta = theta + zs[:, None, None, None, ...]  # (nk, n_b, n_samples, m, 1)
         x = theta * v
 
         # |J|->1 as phi -> 0; cap at 1e-5 for numerical stability

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -56,7 +56,7 @@ class S3(Manifold):
         return 'S(' + str(self.d) + ')'
 
     def lprior(self, g):
-        return self.lprior_const * torch.ones(g.shape[:2])
+        return self.lprior_const * torch.ones(g.shape[:-1])
 
     @staticmethod
     def parameterise(x) -> Tensor:

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -33,11 +33,11 @@ class S3(Manifold):
             special.loggamma(2) - np.log(2) - 2 * np.log(np.pi))
 
     @staticmethod
-    def initialize(initialization, m, d, Y):
+    def initialize(initialization, n_samples, m, d, Y):
         '''initializes latents - can add more exciting initializations as well'''
         # initialize at identity
-        mudata = torch.tensor(np.array([[1, 0, 0, 0] for i in range(m)]),
-                              dtype=torch.get_default_dtype())
+        mudata = torch.zeros(n_samples, m, 4)
+        mudata[:, :, 0] = 1
         return mudata
 
     def inducing_points(self, n, n_z, z=None):

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -73,7 +73,7 @@ class So3(Manifold):
         return 'So3(' + str(self.d) + ')'
 
     def lprior(self, g):
-        return self.lprior_const * torch.ones(g.shape[:2])
+        return self.lprior_const * torch.ones(g.shape[:-1])
 
     @staticmethod
     def parameterise(x) -> Tensor:

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -126,9 +126,9 @@ class So3(Manifold):
         ks = np.arange(-kmax, kmax + 1)
         zs = np.meshgrid(*(ks for _ in range(1)))
         zs = np.stack([z.flatten() for z in zs]).T * np.pi
-        #zs = torch.from_numpy(zs).float().to(theta.device)
         zs = torch.tensor(zs, dtype=torch.get_default_dtype()).to(theta.device)
-        theta = theta + zs[:, None, None, ...]  # (nk, n_b, m, 1)
+        theta = theta + zs[:, None, None, None,
+                           ...]  # (nk, n_b, n_samples, m, 1)
         x = theta * v
 
         # |J|->1 as phi -> 0; cap at 1e-5 for numerical stability

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -40,14 +40,13 @@ class So3(Manifold):
             if Y is None:
                 print('user must provide data for PCA initialization')
             else:
-                Y = Y.reshape(-1, m)
-                pca = decomposition.PCA(n_components=3)
-                mudata = pca.fit_transform(Y.T)  #m x d
-                #constrain to injectivity radius
-                mudata *= 0.5 * np.pi / np.amax(
-                    np.sqrt(np.sum(mudata**2, axis=1)))
+                n = Y.shape[1]
+                pca = decomposition.PCA(n_components=d)
+                Y = Y.transpose(1, 2).reshape(n_samples*m, n)
+                mudata = pca.fit_transform(Y)  #m*n_samples x d
+                mudata *= 0.5 * np.pi / np.amax(np.sqrt(np.sum(mudata**2, axis=1)))
                 mudata = torch.tensor(mudata, dtype=torch.get_default_dtype())
-                return self.expmap(mudata).reshape(n_samples, m, -1)
+                return self.expmap(mudata).reshape(n_samples, m, d)
         # initialize at identity
         mudata = self.expmap(torch.randn(n_samples, m, 3) * 0.1)
         #mudata = torch.tensor(np.array([[1, 0, 0, 0] for i in range(m)]), dtype=torch.get_default_dtype())

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -42,7 +42,7 @@ class So3(Manifold):
             else:
                 n = Y.shape[1]
                 pca = decomposition.PCA(n_components=d)
-                Y = Y.transpose(1, 2).reshape(n_samples*m, n)
+                Y = Y.transpose(0, 2, 1).reshape(n_samples*m, n)
                 mudata = pca.fit_transform(Y)  #m*n_samples x d
                 mudata *= 0.5 * np.pi / np.amax(np.sqrt(np.sum(mudata**2, axis=1)))
                 mudata = torch.tensor(mudata, dtype=torch.get_default_dtype())

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -80,10 +80,11 @@ class Torus(Manifold):
         ks = np.arange(-kmax, kmax + 1)
         zs = np.meshgrid(*(ks for _ in range(d)))
         zs = np.stack([z.flatten() for z in zs]).T * 2. * np.pi
-        zs = torch.from_numpy(zs).float()
+        zs = torch.tensor(zs, dtype=torch.get_default_dtype())
         zs = zs.to(x.device)  # meshgrid shape (2kmax+1)^n
-        y = x + zs[:, None, None, ...]  # meshgrid x n_b x m x d
-        lp = torch.logsumexp(log_base_prob(y), dim=0)  # n_b x m
+        y = x + zs[:, None, None, None,
+                   ...]  # meshgrid x n_b x n_samples, m x d
+        lp = torch.logsumexp(log_base_prob(y), dim=0)  # n_b x n_samples, m
         return lp
 
     @staticmethod

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -49,7 +49,7 @@ class Torus(Manifold):
         return InducingPoints(n, self.d, n_z, z=z)
 
     def lprior(self, g: Tensor) -> Tensor:
-        return self.lprior_const * torch.ones(g.shape[:2])
+        return self.lprior_const * torch.ones(g.shape[:-1])
 
     # log of the uniform prior (negative log volume) for T^d
     @property

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -33,13 +33,12 @@ class Torus(Manifold):
             if Y is None:
                 print('user must provide data for PCA initialization')
             else:
-                Y = Y.reshape(-1, m)
+                n = Y.shape[1]
                 pca = decomposition.PCA(n_components=d)
-                mudata = pca.fit_transform(Y.T)  #m x d
-                #constrain to injectivity radius
-                mudata = mudata * 2 * np.pi / (np.amax(mudata) -
-                                               np.amin(mudata))
-                mudata = mudata.reshape(Y.shape[0], -1, d)
+                Y = Y.transpose(1, 2).reshape(n_samples*m, n)
+                mudata = pca.fit_transform(Y)  #m*n_samples x d
+                mudata *= 2 * np.pi / (np.amax(mudata) - np.amin(mudata))
+                mudata = mudata.reshape(n_samples, m, d)
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())
         mudata = torch.randn(n_samples, m, d) * 0.1
         return mudata

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -35,7 +35,7 @@ class Torus(Manifold):
             else:
                 n = Y.shape[1]
                 pca = decomposition.PCA(n_components=d)
-                Y = Y.transpose(1, 2).reshape(n_samples*m, n)
+                Y = Y.transpose(0, 2, 1).reshape(n_samples*m, n)
                 mudata = pca.fit_transform(Y)  #m*n_samples x d
                 mudata *= 2 * np.pi / (np.amax(mudata) - np.amin(mudata))
                 mudata = mudata.reshape(n_samples, m, d)

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -26,19 +26,22 @@ class Torus(Manifold):
         self.lprior_const = torch.tensor(-self.d * np.log(2 * np.pi))
 
     @staticmethod
-    def initialize(initialization, m, d, Y):
+    def initialize(initialization, n_samples, m, d, Y):
         '''initializes latents - can add more exciting initializations as well'''
         if initialization == 'pca':
             #Y is N x m; reduce to d x m
             if Y is None:
                 print('user must provide data for PCA initialization')
             else:
+                Y = Y.reshape(-1, m)
                 pca = decomposition.PCA(n_components=d)
-                mudata = pca.fit_transform(Y[:, :, 0].T)  #m x d
+                mudata = pca.fit_transform(Y.T)  #m x d
                 #constrain to injectivity radius
-                mudata *= 2 * np.pi / (np.amax(mudata) - np.amin(mudata))
+                mudata = mudata * 2 * np.pi / (np.amax(mudata) -
+                                               np.amin(mudata))
+                mudata = mudata.reshape(Y.shape[0], -1, d)
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())
-        mudata = torch.randn(m, d) * 0.1
+        mudata = torch.randn(n_samples, m, d) * 0.1
         return mudata
 
     def inducing_points(self, n, n_z, z=None):

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -295,7 +295,7 @@ class Svgp(SvgpBase):
         return z
 
     def _expand_x(self, x: Tensor) -> Tensor:
-        x = x[:, None, ...]
+        x = x[:, :, None, ...]
         return x
 
 

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -108,13 +108,13 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         n_mc : int
             number of monte carlo samples
         y : Tensor
-            data tensor with dimensions (n x m)
+            data tensor with dimensions (n_samples x n x m)
         x : Tensor (single kernel) or Tensor list (product kernels)
-            input tensor(s) with dimensions (n_mc x d x m)
+            input tensor(s) with dimensions (n_mc x n_samples x d x m)
 
         Returns
         -------
-        evidence lower bound : torch.Tensor (n_mc x n)
+        evidence lower bound : torch.Tensor (n_mc x n_samples x n)
 
         Notes
         -----
@@ -127,7 +127,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         # predictive mean and var at x
         f_mean, f_var = self.predict(x, full_cov=False)
 
-        #(n_mc, n)
+        #(n_mc, n_samles, n)
         lik = self.likelihood.variational_expectation(y, f_mean, f_var)
         svgp_elbo = lik - prior_kl
         return svgp_elbo
@@ -135,20 +135,20 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
     def tuning(self, query, n_b=1000, square=False):
         '''
         query is mxd
-        return n_b samples from the full model (n_b x n x m)
+        return n_b samples from the full model (n_b x n_samples x n x m)
         if square, the outputs are squared (useful e.g. when fitting sqrt spike counts with a Gaussian likelihood)
         '''
 
         query = torch.unsqueeze(query.T, 0)  #add batch dimension
 
-        mu, v = self.predict(query, False)  #1xnxm, 1xnxm
+        mu, v = self.predict(query, False)  #1xn_samplesxnxm, 1xn_samplesxnxm
         # remove batch dimension
         mu = mu[0]  #n x m,
         v = v[0]  # nxm
 
         #sample from p(f|u)
         dist = Normal(mu, torch.sqrt(v))
-        f_samps = dist.sample((n_b, ))  #n_b x n x m
+        f_samps = dist.sample((n_b, ))  #n_mc x n_samples x n x m
 
         #sample from observation function p(y|f)
         y_samps = self.likelihood.sample(f_samps)
@@ -164,7 +164,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         Parameters
         ----------
         x : Tensor (single kernel) or Tensor list (product kernels)
-            test input tensor(s) with dimensions (n_b x d x m)
+            test input tensor(s) with dimensions (n_b x n_samples x d x m)
         full_cov : bool
             returns full covariance if true otherwise returns the diagonal
 
@@ -188,53 +188,53 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         # see ELBO for explanation of _expand
         z = self._expand_z(z)
         x = self._expand_x(x)
-        kzz = kernel(z, z)  # dims: (1 x n x n_inducing x n_inducing)
-        kzx = kernel(z, x)  # dims: (1 x n x n_inducing x m)
+        kzz = kernel(z, z)  # dims: (n_samples x n x n_inducing x n_inducing)
+        kzx = kernel(z, x)  # dims: (1 x n_samples x n x n_inducing x m)
         e = torch.eye(self.n_inducing,
                       dtype=torch.get_default_dtype()).to(kzz.device)
 
         # [ l ] has dims: (1 x n x n_inducing x n_inducing)
         l = torch.cholesky(kzz + (jitter * e), upper=False)
-        # [ alpha ] has dims: (n_b x n x n_inducing x m)
+        # [ alpha ] has dims: (n_b x n_samples x n x n_inducing x m)
         alpha = torch.triangular_solve(kzx, l, upper=False)[0]
-        alphat = alpha.permute(0, 1, 3, 2)
+        alphat = alpha.transpose(-1, -2)
 
         if self.whiten:
-            # [ mu ] has dims : (n_b x n x m x 1)
+            # [ mu ] has dims : (n_b x n_samples x n x m x 1)
             mu = torch.matmul(alphat, q_mu)
         else:
-            # [ beta ] has dims : (n_b x n x n_inducing x m)
+            # [ beta ] has dims : (n_b x n_samples x n x n_inducing x m)
             beta = torch.triangular_solve(alpha,
-                                          l.permute(0, 1, 3, 2),
+                                          l.transpose(-1, -2),
                                           upper=True)[0]
-            # [ betat ] has dims : (n_b x n x m x n_inducing)
-            betat = beta.permute(0, 1, 3, 2)
+            # [ betat ] has dims : (n_b x n_samples x n x m x n_inducing)
+            betat = beta.transpose(-1, -2)
             mu = torch.matmul(betat, q_mu)
 
         if full_cov:
-            # [ tmp1 ] has dims : (n_b x n x m x n_inducing)
+            # [ tmp1 ] has dims : (n_b x n_samples, n x m x n_inducing)
             if self.whiten:
                 tmp1 = torch.matmul(alphat, q_sqrt)
             else:
                 tmp1 = torch.matmul(betat, q_sqrt)
-            # [ v1 ] has dims : (n_b x n x m x m)
-            v1 = torch.matmul(tmp1, tmp1.permute(0, 1, 3, 2))
-            # [ v2 ] has dims : (n_b x n x m x m)
+            # [ v1 ] has dims : (n_b x n_samples x n x m x m)
+            v1 = torch.matmul(tmp1, tmp1.transpose(-1, -2))
+            # [ v2 ] has dims : (n_b x n_samples x n x m x m)
             v2 = torch.matmul(alphat, alphat)
-            # [ kxx ] has dims : (n_b x n x m x m)
+            # [ kxx ] has dims : (n_b x n_samples x n x m x m)
             kxx = kernel(x, x)
             v = kxx + v1 - v2
         else:
-            # [ kxx ] has dims : (n_b x n x m)
+            # [ kxx ] has dims : (n_b x n_samples x n x m)
             kxx = kernel.diagK(x)
-            # [ tmp1 ] has dims : (n_b x n x m x n_inducing)
+            # [ tmp1 ] has dims : (n_b x n_samples x n x m x n_inducing)
             if self.whiten:
                 tmp1 = torch.matmul(alphat, q_sqrt)
             else:
                 tmp1 = torch.matmul(betat, q_sqrt)
-            # [ v1 ] has dims : (n_b x n x m)
+            # [ v1 ] has dims : (n_b x n_samples x n x m)
             v1 = torch.square(tmp1).sum(-1)
-            # [ v2 ] has dims : (n_b x n x m)
+            # [ v2 ] has dims : (n_b x n_samples x n x m)
             v2 = torch.square(alpha).sum(-2)
             v = kxx + v1 - v2
 

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -103,9 +103,8 @@ class SvgpLvm(nn.Module):
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)
         # and so we need to permute [ g ] to have the right dimensions
 
-        svgp_elbo = self.svgp.elbo(n_mc, data,
-                                   g.transpose(-1,
-                                               -2))  #(n_samples x n_mc x n)
+        #(n_samples x n_mc x n)
+        svgp_elbo = self.svgp.elbo(n_mc, data, g.transpose(-1, -2))
         if neuron_idxs is not None:
             svgp_elbo = svgp_elbo[..., neuron_idxs, :]
 

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -97,7 +97,7 @@ class SvgpLvm(nn.Module):
         g, lq = self.lat_dist.sample(torch.Size([n_mc]), data, batch_idxs)
         # g is shape (n_samples, n_mc, m, d)
 
-        data = data if batch_idxs is None else data[:, batch_idxs]
+        data = data if batch_idxs is None else data[:, :, batch_idxs]
         ts = ts if (ts is None or batch_idxs is None) else ts[batch_idxs]
 
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -106,7 +106,9 @@ class SvgpLvm(nn.Module):
         #(n_samples x n_mc x n)
         svgp_elbo = self.svgp.elbo(n_mc, data, g.transpose(-1, -2))
         if neuron_idxs is not None:
-            svgp_elbo = svgp_elbo[..., neuron_idxs, :]
+            #print('pre:', svgp_elbo.shape)
+            svgp_elbo = svgp_elbo[..., neuron_idxs]
+            #print('post:', svgp_elbo.shape)
 
         # compute kl term for the latents (n_mc, n_samples)
         prior = self.lprior(g, ts)  #(n_mc, n_samples)

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -50,7 +50,7 @@ def print_progress(model,
         mu = model.lat_dist.lat_gmu(Y, batch_idxs).data.cpu().numpy()
         gamma = model.lat_dist.lat_gamma(Y, batch_idxs).diagonal(
             dim1=-1, dim2=-2).data.cpu().numpy()
-        mu_mag = np.mean(np.sqrt(gamma))
+        mu_mag = np.mean(np.sqrt(mu**2))
         sig = np.median(np.concatenate([np.diag(sig) for sig in gamma]))
         msg = ('\riter {:3d} | elbo {:.3f} | kl {:.3f} | loss {:.3f} ' +
                '| |mu| {:.3f} | sig {:.3f} |').format(i,

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -39,6 +39,7 @@ def sort_params(model, hook):
 def print_progress(model,
                    n,
                    m,
+                   n_samples,
                    i,
                    loss_val,
                    kl_val,
@@ -47,6 +48,7 @@ def print_progress(model,
                    Y=None,
                    batch_idxs=None):
     if i % print_every == 0:
+        Z = n*m*n_samples
         mu = model.lat_dist.lat_gmu(Y, batch_idxs).data.cpu().numpy()
         gamma = model.lat_dist.lat_gamma(Y, batch_idxs).diagonal(
             dim1=-1, dim2=-2).data.cpu().numpy()
@@ -54,9 +56,9 @@ def print_progress(model,
         sig = np.median(np.concatenate([np.diag(sig) for sig in gamma]))
         msg = ('\riter {:3d} | elbo {:.3f} | kl {:.3f} | loss {:.3f} ' +
                '| |mu| {:.3f} | sig {:.3f} |').format(i,
-                                                      svgp_elbo_val / (n * m),
-                                                      kl_val / (n * m),
-                                                      loss_val / (n * m),
+                                                      svgp_elbo_val / Z,
+                                                      kl_val / Z,
+                                                      loss_val / Z,
                                                       mu_mag, sig)
         print(msg + model.kernel.msg + model.lprior.msg, end="\r")
 
@@ -169,7 +171,7 @@ def fit(Y,
         loss.backward()
         opt.step()
         scheduler.step()
-        print_progress(model, n, m, i, loss_val, kl_val, svgp_elbo_val,
+        print_progress(model, n, m, data.shape[0], i, loss_val, kl_val, svgp_elbo_val,
                        print_every, data, batch_idxs)
 
     return model

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -47,16 +47,11 @@ def print_progress(model,
                    Y=None,
                    batch_idxs=None):
     if i % print_every == 0:
-        mu_mag = np.mean(
-            np.sqrt(
-                np.sum(model.lat_dist.lat_gmu(
-                    Y, batch_idxs).data.cpu().numpy()[:]**2,
-                       axis=1)))
-        sig = np.median(
-            np.concatenate([
-                np.diag(sig) for sig in model.lat_dist.lat_gamma(
-                    Y, batch_idxs).data.cpu().numpy()
-            ]))
+        mu = model.lat_dist.lat_gmu(Y, batch_idxs).data.cpu().numpy()
+        gamma = model.lat_dist.lat_gamma(Y, batch_idxs).diagonal(
+            dim1=-1, dim2=-2).data.cpu().numpy()
+        mu_mag = np.mean(np.sqrt(gamma))
+        sig = np.median(np.concatenate([np.diag(sig) for sig in gamma]))
         msg = ('\riter {:3d} | elbo {:.3f} | kl {:.3f} | loss {:.3f} ' +
                '| |mu| {:.3f} | sig {:.3f} |').format(i,
                                                       svgp_elbo_val / (n * m),

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -97,12 +97,14 @@ class _F(Module):
             gmu = self.manif.initialize(initialization, n_samples, m, manif.d,
                                         Y)
         else:
+            assert mu.shape == (n_samples, m, manif.d2)
             gmu = torch.tensor(mu)
         self.gmu = nn.Parameter(data=gmu, requires_grad=True)
 
         if gamma is None:
             gamma = torch.ones(n_samples, m, manif.d) * sigma
-
+        assert gamma.shape == (n_samples, m, manif.d)
+        
         if diagonal:
             gamma = inv_softplus(gamma)
         else:

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -49,9 +49,9 @@ class ReLieBase(Rdist):
         """
         gmu, gamma = self.lat_prms(Y, batch_idxs)
         q = self.mvn(gamma)
-        # sample a batch with dims: (n_mc x batch_size x d)
+        # sample a batch with dims: (n_mc x n_samples x batch_size x d)
         x = q.rsample(size)
-        m = x.shape[1]
+        m = x.shape[-2]
         mu = torch.zeros(m).to(gamma.device)[..., None]
         if self.diagonal:  #compute diagonal covariance
             lq = torch.stack([

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -39,8 +39,8 @@ class ReLieBase(Rdist):
 
     def mvn(self, gamma=None):
         gamma = self.lat_gamma() if gamma is None else gamma
-        m = gamma.shape[0]
-        mu = torch.zeros(m, self.d).to(gamma.device)
+        n_samples, m, _, _ = gamma.shape
+        mu = torch.zeros(n_samples, m, self.d).to(gamma.device)
         return MultivariateNormal(mu, scale_tril=gamma)
 
     def sample(self, size, Y=None, batch_idxs=None, kmax=5):

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -116,7 +116,7 @@ class _F(Module):
         if batch_idxs is None:
             return gmu, gamma
         else:
-            return gmu[:, batch_idxs], gamma[:, batch_idxs]
+            return gmu[:, batch_idxs, :], gamma[:, batch_idxs, :]
 
     @property
     def prms(self):

--- a/mgplvm/syndata/gen_data.py
+++ b/mgplvm/syndata/gen_data.py
@@ -256,8 +256,8 @@ class Gen():
     def set_param(self, param, value):
         '''set the value of a parameter'''
         if param == "l":  # need separate lengthscale per neuron per manifold
-            if type(value) in [int,
-                               float]:  # one length scale for each manifold
+            if type(value) in [int, float, np.float64
+                               ]:  # one length scale for each manifold
                 value = [value for i in range(self.nman)]
             value = [
                 np.ones((self.n, 1)) * val +

--- a/mgplvm/syndata/gen_data.py
+++ b/mgplvm/syndata/gen_data.py
@@ -16,9 +16,9 @@ def draw_GP(n, d, n_samples, sig, ell, jitter=1e-6):
     K = sig**2 * np.exp(-dts**2 / (2 * ell**2))  #nxn
     L = np.linalg.cholesky(K + jitter * np.eye(n))  #nxn
 
-    us = np.random.normal(size=(n_samples * n, d))  #nxd
-    X = L @ us  #nxd
-    return X.reshape(n_samples, n, d)
+    us = np.random.normal(size=(n_samples, n, d))  #n_samples x n x d
+    X = L @ us  #n_samples x n x d (numpy deals with the shapes correctly here)
+    return X
 
 
 class Manif(metaclass=abc.ABCMeta):
@@ -294,7 +294,6 @@ class Gen():
         return gs
 
     def gen_data(self,
-                 n_samples=1,
                  gs_in=None,
                  gprefs_in=None,
                  mode='Gaussian',

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -22,8 +22,8 @@ def test_cv_runs():
     m = 10  # number of conditions / time points
     n_z = 6  # number of inducing points
     n_samples = 1  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data(n_samples = n_samples)
+    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25, n_samples=n_samples)
+    Y = gen.gen_data()
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
     lat_dist = mgplvm.rdist.ReLie(manif,

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,0 +1,48 @@
+import numpy as np
+import torch
+from torch import optim
+import mgplvm
+from mgplvm import kernels, rdist, models, optimisers, syndata, likelihoods
+from mgplvm.manifolds import Torus, Euclid, So3
+import matplotlib.pyplot as plt
+torch.set_default_dtype(torch.float64)
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+else:
+    device = torch.device("cpu")
+
+
+def test_cv_runs():
+    """
+    test that svgp runs without explicit check for correctness
+    also test that burda log likelihood runs and is smaller than elbo
+    """
+    d = 1  # dims of latent space
+    n = 8  # number of neurons
+    m = 10  # number of conditions / time points
+    n_z = 6  # number of inducing points
+    n_samples = 1  # number of samples
+    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
+    Y = gen.gen_data()
+    # specify manifold, kernel and rdist
+    manif = Euclid(m, d)
+    lat_dist = mgplvm.rdist.ReLie(manif,
+                                  m,
+                                  n_samples,
+                                  diagonal=False)
+    kernel = kernels.QuadExp(n, manif.distance)
+    lik = likelihoods.Gaussian(n)
+    lprior = mgplvm.lpriors.Uniform(manif)
+    z = manif.inducing_points(n, n_z)
+    mod = models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+                         whiten=True).to(device)
+
+    ### run cv ###
+    train_ps = mgplvm.crossval.training_params(lrate = 5e-2, burnin = 20, ts=None, batch_size = None,
+                                                  max_steps = 10, n_mc = 32)
+    mod, split = mgplvm.crossval.train_cv(mod,Y,device,train_ps,test = False)
+    _ = mgplvm.crossval.test_cv(mod, split, device, Print = True)
+
+
+if __name__ == '__main__':
+    test_cv_runs()

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -23,7 +23,7 @@ def test_cv_runs():
     n_z = 6  # number of inducing points
     n_samples = 1  # number of samples
     gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data()
+    Y = gen.gen_data(n_samples = n_samples)
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
     lat_dist = mgplvm.rdist.ReLie(manif,

--- a/tests/test_entropies.py
+++ b/tests/test_entropies.py
@@ -12,11 +12,13 @@ device = mgplvm.utils.get_device()
 
 def test_euclid(kmax=5, savefig=False):
     m = 100
+    n_samples = 1
     for d in [1, 2, 3]:
 
         manif = Euclid(m, d)
         sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-        q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
+        q = mgplvm.rdist.ReLie(manif, m, n_samples,
+                               sigma=torch.tensor(sigmas)).mvn()
         x = q.rsample(torch.Size([200]))
         lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
         H = -lq.mean(dim=0).detach().numpy()
@@ -42,12 +44,14 @@ def test_euclid(kmax=5, savefig=False):
 def test_torus(kmax=5, savefig=False):
 
     m = 100
+    n_samples = 2
 
     for d in [1, 2, 3]:
 
         manif = Torus(m, d)
         sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-        q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
+        q = mgplvm.rdist.ReLie(manif, m, n_samples,
+                               sigma=torch.tensor(sigmas)).mvn()
         x = q.rsample(torch.Size([200]))
         lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
         H = -lq.mean(dim=0).detach().numpy()
@@ -77,8 +81,10 @@ def test_torus(kmax=5, savefig=False):
 def test_so3(kmax=5, savefig=False):
     m = 100
     manif = So3(m)
+    n_samples = 2
     sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-    q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
+    q = mgplvm.rdist.ReLie(manif, m, n_samples,
+                           sigma=torch.tensor(sigmas)).mvn()
     x = q.rsample(torch.Size([200]))
     lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
     H = -lq.mean(dim=0).detach().numpy()
@@ -103,10 +109,12 @@ def test_so3(kmax=5, savefig=False):
 
 def test_s3(kmax=5, savefig=False):
     m = 100
+    n_samples = 2
 
     manif = S3(m)
     sigmas = 10**np.linspace(-2, 1, num=m).reshape(m, 1)
-    q = mgplvm.rdist.ReLie(manif, m, sigma=torch.tensor(sigmas)).mvn()
+    q = mgplvm.rdist.ReLie(manif, m, n_samples,
+                           sigma=torch.tensor(sigmas)).mvn()
 
     x = q.rsample(torch.Size([200]))
     lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)

--- a/tests/test_entropies.py
+++ b/tests/test_entropies.py
@@ -12,7 +12,7 @@ device = mgplvm.utils.get_device()
 
 def test_euclid(kmax=5, savefig=False):
     m = 100
-    n_samples = 1
+    n_samples = 2
     for d in [1, 2, 3]:
 
         manif = Euclid(m, d)
@@ -21,8 +21,8 @@ def test_euclid(kmax=5, savefig=False):
                                sigma=torch.tensor(sigmas)).mvn()
         x = q.rsample(torch.Size([200]))
         lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
-        H = -lq.mean(dim=0).detach().numpy()
-        std = lq.std(dim=0).detach().numpy()
+        H = -lq.mean(dim=0).mean(dim=0).detach().numpy()
+        std = lq.std(dim=0).mean(dim=0).detach().numpy()
 
         Hgauss = d / 2 + d / 2 * np.log(2 * np.pi) + d * np.log(sigmas[:, 0])
 
@@ -38,6 +38,7 @@ def test_euclid(kmax=5, savefig=False):
             plt.xscale('log')
             plt.savefig('test_euclid' + str(d) + '.png', dpi=120)
             plt.close()
+
         assert all(np.abs(H - Hgauss) < std)  # adhere to bound
 
 
@@ -54,8 +55,8 @@ def test_torus(kmax=5, savefig=False):
                                sigma=torch.tensor(sigmas)).mvn()
         x = q.rsample(torch.Size([200]))
         lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
-        H = -lq.mean(dim=0).detach().numpy()
-        std = lq.std(dim=0).detach().numpy()
+        H = -lq.mean(dim=0).mean(dim=0).detach().numpy()
+        std = lq.std(dim=0).mean(dim=0).detach().numpy()
 
         Hmax = -manif.lprior_const
         Hgauss = d / 2 + d / 2 * np.log(2 * np.pi) + d * np.log(sigmas)
@@ -87,8 +88,8 @@ def test_so3(kmax=5, savefig=False):
                            sigma=torch.tensor(sigmas)).mvn()
     x = q.rsample(torch.Size([200]))
     lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
-    H = -lq.mean(dim=0).detach().numpy()
-    std = lq.std(dim=0).detach().numpy()
+    H = -lq.mean(dim=0).mean(dim=0).detach().numpy()
+    std = lq.std(dim=0).mean(dim=0).detach().numpy()
 
     Hmax = -manif.lprior_const
     Hgauss = 3 / 2 + 3 / 2 * np.log(2 * np.pi) + 3 * np.log(sigmas)
@@ -118,8 +119,8 @@ def test_s3(kmax=5, savefig=False):
 
     x = q.rsample(torch.Size([200]))
     lq = manif.log_q(q.log_prob, x, manif.d, kmax=kmax)
-    H = -lq.mean(dim=0).detach().numpy()
-    std = lq.std(dim=0).detach().numpy()
+    H = -lq.mean(dim=0).mean(dim=0).detach().numpy()
+    std = lq.std(dim=0).mean(dim=0).detach().numpy()
 
     Hmax = -manif.lprior_const
     Hgauss = 3 / 2 + 3 / 2 * np.log(2 * np.pi) + 3 * np.log(sigmas)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -70,7 +70,7 @@ def test_kernels_run():
                       sigma=0.8,
                       beta=0.1)
     sig0 = 1.5
-    Y = gen.gen_data(ell=25, sig=1)
+    Y = gen.gen_data(ell=25, sig=1, n_samples = n_samples)
 
     kernels = [
         QuadExp(n, Euclid.distance),

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -60,7 +60,7 @@ def test_kernels_run():
     n = 100  # number of neurons
     m = 250  # number of conditions / time points
     n_z = 15  # number of inducing points
-    n_samples = 1  # number of samples
+    n_samples = 2  # number of samples
     l = float(0.55 * np.sqrt(d))
     gen = syndata.Gen(syndata.Euclid(d),
                       n,
@@ -80,7 +80,7 @@ def test_kernels_run():
     for kernel in kernels:
         # specify manifold, kernel and rdist
         manif = Euclid(m, d)
-        lat_dist = mgplvm.rdist.ReLie(manif, m, initialization='random')
+        lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, initialization='random')
         # generate model
         lik = likelihoods.Gaussian(n)
         lprior = lpriors.Uniform(manif)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -68,9 +68,10 @@ def test_kernels_run():
                       variability=0.15,
                       l=l,
                       sigma=0.8,
-                      beta=0.1)
+                      beta=0.1,
+                      n_samples=n_samples)
     sig0 = 1.5
-    Y = gen.gen_data(ell=25, sig=1, n_samples = n_samples)
+    Y = gen.gen_data(ell=25, sig=1)
 
     kernels = [
         QuadExp(n, Euclid.distance),

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -23,7 +23,7 @@ def test_likelihood_runs():
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
     gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data()
+    Y = gen.gen_data(n_samples = n_samples)
     Y = np.round(Y - np.amin(Y))
     print(Y.shape)
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -21,7 +21,7 @@ def test_likelihood_runs():
     n = 5  # number of neurons
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
-    n_samples = 1  # number of samples
+    n_samples = 2  # number of samples
     gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
     Y = gen.gen_data()[0]
     Y = np.round(Y - np.amin(Y))
@@ -35,7 +35,7 @@ def test_likelihood_runs():
     ]:
         # specify manifold, kernel and rdist
         manif = Euclid(m, d)
-        lat_dist = mgplvm.rdist.ReLie(manif, m, diagonal=False)
+        lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, diagonal=False)
         # initialize signal variance
         kernel = kernels.QuadExp(n, manif.distance)
         # generate model
@@ -59,7 +59,7 @@ def test_likelihood_runs():
         LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
         print("once")
         svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
-        elbo = (svgp_elbo - kl) / (Y.shape[0] * Y.shape[1])
+        elbo = (svgp_elbo - kl).mean() / Y.shape[-1]
 
         assert elbo <= LL
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -23,8 +23,9 @@ def test_likelihood_runs():
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
     gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data()[0]
+    Y = gen.gen_data()
     Y = np.round(Y - np.amin(Y))
+    print(Y.shape)
 
     for lik in [
             likelihoods.Gaussian(n),
@@ -59,7 +60,7 @@ def test_likelihood_runs():
         LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
         print("once")
         svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
-        elbo = (svgp_elbo - kl).mean() / Y.shape[-1]
+        elbo = (svgp_elbo - kl) / np.prod(Y.shape)
 
         assert elbo <= LL
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -22,8 +22,8 @@ def test_likelihood_runs():
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data(n_samples = n_samples)
+    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25, n_samples=n_samples)
+    Y = gen.gen_data()
     Y = np.round(Y - np.amin(Y))
     print(Y.shape)
 

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -26,14 +26,15 @@ def test_so3_dimensions():
 
 
 def test_manifs_runs():
-    m, d, n, n_z = 10, 3, 5, 5
-    Y = np.random.normal(0, 1, (n, m))
+    m, d, n, n_z, n_samples = 10, 3, 5, 5, 2
+    Y = np.random.normal(0, 1, (n_samples, n, m))
     for i, manif_type in enumerate(
         [manifolds.Torus, manifolds.So3, manifolds.S3]):
         manif = manif_type(m, d)
         print(manif.name)
         lat_dist = mgplvm.rdist.ReLie(manif,
                                       m,
+                                      n_samples,
                                       sigma=0.4,
                                       diagonal=(True if i == 0 else False))
         kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y=Y)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,7 +21,7 @@ def test_svgp_runs():
     n = 8  # number of neurons
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
-    n_samples = 1  # number of samples
+    n_samples = 2  # number of samples
     gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
     sig0 = 1.5
     l = 0.4

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,7 @@ def test_svgp_runs():
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
     gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data()
+    Y = gen.gen_data(n_samples = n_samples)
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
     lat_dist = mgplvm.rdist.ReLie(manif,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,9 +52,17 @@ def test_svgp_runs():
     LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
     svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
     elbo = (svgp_elbo - kl) / np.prod(Y.shape)
-
+    
     assert elbo < LL
-
+    
+    #### test that batching works ####
+    trained_model = optimisers.svgp.fit(Y,
+                                        mod,
+                                        device,
+                                        optimizer=optim.Adam,
+                                        max_steps=5,
+                                        n_mc=64,
+                                        batch_size = int(np.round(m/2, 0)))
 
 if __name__ == '__main__':
     test_svgp_runs()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ def test_svgp_runs():
     also test that burda log likelihood runs and is smaller than elbo
     """
     d = 1  # dims of latent space
-    n = 5  # number of neurons
+    n = 8  # number of neurons
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 1  # number of samples
@@ -26,16 +26,20 @@ def test_svgp_runs():
     sig0 = 1.5
     l = 0.4
     gen.set_param('l', l)
-    Y = gen.gen_data()[0]
+    Y = gen.gen_data()
     Y = Y + np.random.normal(size=Y.shape) * np.mean(Y) / 3
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
-    lat_dist = mgplvm.rdist.ReLie(manif, m, sigma=sig0, diagonal=False)
+    lat_dist = mgplvm.rdist.ReLie(manif,
+                                  m,
+                                  n_samples,
+                                  sigma=sig0,
+                                  diagonal=False)
     # initialize signal variance
-    alpha = np.std(Y, axis=1)
+    alpha = np.mean(np.std(Y, axis=-1), axis=0)
     kernel = kernels.QuadExp(n, manif.distance, alpha=alpha)
     # generate model
-    sigma = np.std(Y, axis=1)  # initialize noise
+    sigma = np.mean(np.std(Y, axis=-1), axis=0)  # initialize noise
     lik = likelihoods.Gaussian(n, variance=np.square(sigma))
     lprior = mgplvm.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,8 +22,8 @@ def test_svgp_runs():
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25)
-    Y = gen.gen_data(n_samples = n_samples)
+    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25, n_samples=n_samples)
+    Y = gen.gen_data()
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
     lat_dist = mgplvm.rdist.ReLie(manif,

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -14,8 +14,8 @@ def test_GP_prior():
     n = 100  # number of neurons
     m = 250  # number of conditions / time points
     n_z = 15  # number of inducing points
-    n_samples = 1  # number of samples
-    l = float(0.55 * np.sqrt(d))
+    n_samples = 2  # number of samples
+    l = 0.55 * np.sqrt(d)
     gen = mgplvm.syndata.Gen(mgplvm.syndata.Euclid(d),
                              n,
                              m,
@@ -24,16 +24,17 @@ def test_GP_prior():
                              sigma=0.8,
                              beta=0.1)
     sig0 = 1.5
-    Y = gen.gen_data(ell=25, sig=1)[0]
+    Y = gen.gen_data(ell=25, sig=1)
     # specify manifold, kernel and rdist
     manif = mgplvm.manifolds.Euclid(m, d)
-    alpha = np.std(Y, axis=1)
-    sigma = np.std(Y, axis=1)  # initialize noise
+    alpha = np.mean(np.std(Y, axis=-1), axis=0)
+    sigma = np.mean(np.std(Y, axis=-1), axis=0)  # initialize noise
     kernel = mgplvm.kernels.QuadExp(n, manif.distance, alpha=alpha)
 
     #lat_dist = mgplvm.rdist.MVN(m, d, sigma=sig0)
     lat_dist = mgplvm.rdist.ReLie(manif,
                                   m,
+                                  n_samples,
                                   sigma=sig0,
                                   initialization='random',
                                   Y=Y)
@@ -52,7 +53,7 @@ def test_GP_prior():
                                 lprior).to(device)
 
     ### test that training runs ###
-    ts = torch.arange(m).to(device)
+    ts = torch.arange(m).to(device)[None, ...].repeat(n_samples, 1)
     n_mc = 64
     trained_mod = mgplvm.optimisers.svgp.fit(Y,
                                              mod,
@@ -67,23 +68,20 @@ def test_GP_prior():
 
     ### test that two ways of computing the prior agree ###
     data = torch.tensor(Y).to(device)
-    ts = torch.arange(m).to(device)
     g, lq = mod.lat_dist.sample(torch.Size([n_mc]), data, None)
 
     x = g  #input to prior
 
     #### naive computation ####
     LLs1 = [
-        mod.lprior.svgp.elbo(1, x[i].transpose(-1, -2), ts.reshape(1, 1, -1))
+        mod.lprior.svgp.elbo(1, x[i].transpose(-1, -2), ts)
         for i in range(x.shape[0])
     ]
     elbo1_b = torch.stack([LL.sum() for LL in LLs1], dim=0)
 
     #### try to batch things ####
-    elbo2_b = mod.lprior.svgp.elbo(1,
-                                   x.transpose(-1, -2).reshape(-1, m),
-                                   ts.reshape(1, 1, -1))
-    elbo2_b = elbo2_b.reshape(n_mc, d).sum(-1)
+    elbo2_b = mod.lprior.svgp.elbo(1, x.transpose(-1, -2), ts)
+    elbo2_b = elbo2_b.sum(-1).sum(-1)
     print(elbo1_b.shape, elbo2_b.shape)
 
     ### print comparison ###
@@ -96,13 +94,18 @@ def test_GP_prior():
 
 def test_ARP_runs():
     m, d, n, n_z, p = 10, 3, 5, 5, 1
-    Y = np.random.normal(0, 1, (n, m))
+    n_samples = 2
+    Y = np.random.normal(0, 1, (n_samples, n, m))
     for i, manif_type in enumerate(
         [manifolds.Euclid, manifolds.Torus, manifolds.So3]):
         manif = manif_type(m, d)
         print(manif.name)
         lat_dist = mgplvm.rdist.ReLie(
-            manif, m, sigma=0.4, diagonal=(True if i in [0, 1] else False))
+            manif,
+            m,
+            n_samples,
+            sigma=0.4,
+            diagonal=(True if i in [0, 1] else False))
         kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y=Y)
         # generate model
         lik = mgplvm.likelihoods.Gaussian(n)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -22,9 +22,10 @@ def test_GP_prior():
                              variability=0.15,
                              l=l,
                              sigma=0.8,
-                             beta=0.1)
+                             beta=0.1,
+                             n_samples=n_samples)
     sig0 = 1.5
-    Y = gen.gen_data(ell=25, sig=1,n_samples = n_samples)
+    Y = gen.gen_data(ell=25, sig=1)
     # specify manifold, kernel and rdist
     manif = mgplvm.manifolds.Euclid(m, d)
     alpha = np.mean(np.std(Y, axis=-1), axis=0)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -24,7 +24,7 @@ def test_GP_prior():
                              sigma=0.8,
                              beta=0.1)
     sig0 = 1.5
-    Y = gen.gen_data(ell=25, sig=1)
+    Y = gen.gen_data(ell=25, sig=1,n_samples = n_samples)
     # specify manifold, kernel and rdist
     manif = mgplvm.manifolds.Euclid(m, d)
     alpha = np.mean(np.std(Y, axis=-1), axis=0)


### PR DESCRIPTION
As discusses in #16 , I've added back the `n_samples` dimension to `Y` and also now to the latents: `Y` now has dimensions `n_samples x n x m` and the latents have dimensions `n_samples x d x m`. All the tests are passing at the moment, but I have doubts as to how this affects the priors. I've fixed the GP prior and the ARP prior seems to work out of the box. Before merging, we should probable write tests for the Brownian prior and the priors in `lpriors/torus.py`. 

Going forward, we should probably make the `n_samples` dimension optional, so that if the user passes in `Y` with dimensions `n x m`, it is possible to also learn latents with dimensions `d x m`.  Before doing that, we should probable make sure that this version is somewhat stable. 