### PR TITLE
Fixed bug in elbo of svgp  when batching

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -7,9 +7,13 @@ import numpy as np
 
 
 def model_params(n, m, d, n_z, n_samples, **kwargs):
-    
+
     params = {
-        'n': n, 'm': m, 'd': d, 'n_z': n_z, 'n_samples': n_samples,
+        'n': n,
+        'm': m,
+        'd': d,
+        'n_z': n_z,
+        'n_samples': n_samples,
         'manifold': 'euclid',
         'kernel': 'RBF',
         'prior': 'Uniform',
@@ -25,25 +29,25 @@ def model_params(n, m, d, n_z, n_samples, **kwargs):
         'RBF_alpha': None,
         'RBF_ell': None,
         'arp_p': 1,
-        'arp_eta': np.ones(d)*0.3,
+        'arp_eta': np.ones(d) * 0.3,
         'arp_learn_eta': True,
         'arp_learn_c': False,
         'arp_learn_phi': True,
         'lik_gauss_std': None,
         'device': None
     }
-    
+
     for key, value in kwargs.items():
         params[key] = value
-    
+
     return params
+
 
 def load_model(params):
 
-    likelihoods = {'GP': lpriors.GP}
-    
-    n, m, d, n_z, n_samples = params['n'], params['m'], params['d'], params['n_z'], params['n_samples']
-    
+    n, m, d, n_z, n_samples = params['n'], params['m'], params['d'], params[
+        'n_z'], params['n_samples']
+
     #### specify manifold ####
     if params['manifold'] == 'euclid':
         manif = Euclid(m, d)
@@ -52,54 +56,72 @@ def load_model(params):
     elif params['manifold'] in ['SO3', 'So3', 'so3', 'SO(3)']:
         manif = So3(m, 3)
         params['diagonal'] = False
-        
+
     #### specify latent distribution ####
-    lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, sigma=params['latent_sigma'], diagonal = params['diagonal'],
-                                 initialization = params['initialization'], Y = params['Y'],
-                                 mu = params['latent_mu'])
-    
+    lat_dist = mgplvm.rdist.ReLie(manif,
+                                  m,
+                                  n_samples,
+                                  sigma=params['latent_sigma'],
+                                  diagonal=params['diagonal'],
+                                  initialization=params['initialization'],
+                                  Y=params['Y'],
+                                  mu=params['latent_mu'])
+
     #### specify kernel ####
     if params['kernel'] == 'linear':
-        kernel = kernels.Linear(n, manif.linear_distance, d, learn_weights = params['learn_linear_weights'],
-                                learn_alpha = params['learn_linear_alpha'], Y = params['Y'], alpha = params['linear_alpha'])
+        kernel = kernels.Linear(n,
+                                manif.linear_distance,
+                                d,
+                                learn_weights=params['learn_linear_weights'],
+                                learn_alpha=params['learn_linear_alpha'],
+                                Y=params['Y'],
+                                alpha=params['linear_alpha'])
     elif params['kernel'] == 'RBF':
-        ell = None if params['RBF_ell'] is None else np.ones(n)*params['RBF_ell']
-        kernel = kernels.QuadExp(n, manif.distance, Y = params['Y'],
-                                 alpha = params['RBF_alpha'], ell = ell)
-        
+        ell = None if params['RBF_ell'] is None else np.ones(
+            n) * params['RBF_ell']
+        kernel = kernels.QuadExp(n,
+                                 manif.distance,
+                                 Y=params['Y'],
+                                 alpha=params['RBF_alpha'],
+                                 ell=ell)
+
     #### speciy prior ####
     if params['prior'] == 'GP':
-        lprior_kernel = kernels.QuadExp(d, manif.distance, learn_alpha = False, ell = np.ones(n)*m/20)
-        lprior = lpriors.GP(manif, lprior_kernel, n_z = n_z, tmax = m)
+        lprior_kernel = kernels.QuadExp(d,
+                                        manif.distance,
+                                        learn_alpha=False,
+                                        ell=np.ones(n) * m / 20)
+        lprior = lpriors.GP(manif,
+                            lprior_kernel,
+                            n_z=n_z,
+                            ts=params['ts'],
+                            tmax=m)
     elif params['prior'] == 'ARP':
-        lprior = lpriors.ARP(params['arp_p'], manif, ar_eta = torch.tensor(params['arp_eta']),
-                         learn_eta = params['arp_learn_eta'], learn_c = params['arp_learn_c'],
-                            diagonal = params['diagonal'])
+        lprior = lpriors.ARP(params['arp_p'],
+                             manif,
+                             ar_eta=torch.tensor(params['arp_eta']),
+                             learn_eta=params['arp_learn_eta'],
+                             learn_c=params['arp_learn_c'],
+                             diagonal=params['diagonal'])
     else:
         lprior = lpriors.Uniform(manif)
 
     #### specify likelihood ####
     if params['likelihood'] == 'Gaussian':
-        var = None if params['lik_gauss_std'] is None else np.square(params['lik_gauss_std'])
+        var = None if params['lik_gauss_std'] is None else np.square(
+            params['lik_gauss_std'])
         likelihood = mgplvm.likelihoods.Gaussian(n, variance=var)
     elif params['likelihood'] == 'Poisson':
         likelihood = mgplvm.likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':
         likelihood = mgplvm.likelihoods.NegativeBinomial(n)
-        
+
     #### specify inducing points ####
     z = manif.inducing_points(n, n_z)
-    
+
     #### construct model ####
-    device = (mgplvm.utils.get_device() if params['device'] is None else params['device'])
-    mod = models.SvgpLvm(n,
-                     z,
-                     kernel,
-                     likelihood,
-                     lat_dist,
-                     lprior).to(device)
-    
+    device = (mgplvm.utils.get_device()
+              if params['device'] is None else params['device'])
+    mod = models.SvgpLvm(n, z, kernel, likelihood, lat_dist, lprior).to(device)
+
     return mod
-    
-    
-    

--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -80,7 +80,8 @@ def load_model(params):
 
     #### specify likelihood ####
     if params['likelihood'] == 'Gaussian':
-        likelihood = mgplvm.likelihoods.Gaussian(n, variance=np.square(params['lik_gauss_std']))
+        var = None if params['lik_gauss_std'] is None else np.square(params['lik_gauss_std'])
+        likelihood = mgplvm.likelihoods.Gaussian(n, variance=var)
     elif params['likelihood'] == 'Poisson':
         likelihood = mgplvm.likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -1,20 +1,15 @@
-import os
 import numpy as np
 import copy
-import mgplvm
 import torch
-from mgplvm import kernels, rdist, models 
-from mgplvm.manifolds import Torus, Euclid, So3
-import matplotlib.pyplot as plt
-import pickle
-from scipy.stats import ttest_1samp
-from . import train_model, load_model
+from . import train_model
 torch.set_default_dtype(torch.float64)
+
 
 def not_in(arr, inds):
     mask = np.ones(arr.size, dtype=bool)
     mask[inds] = False
     return arr[mask]
+
 
 def update_params(params, **kwargs):
     newps = copy.copy(params)
@@ -22,15 +17,16 @@ def update_params(params, **kwargs):
         newps[key] = value
     return newps
 
+
 def train_cv(mod,
              Y,
-            device,
-            train_ps,
-            T1 = None,
-            N1 = None,
-            nt_train = None,
-            nn_train = None,
-            test = True):
+             device,
+             train_ps,
+             T1=None,
+             N1=None,
+             nt_train=None,
+             nn_train=None,
+             test=True):
     """
     Parameters
     ----------
@@ -58,76 +54,78 @@ def train_cv(mod,
 
     """
 
-    n_samples, n, m = Y.shape
-    nt_train = int(round(m/2)) if nt_train is None else nt_train
-    nn_train = int(round(n/2)) if nn_train is None else nn_train
-    
-    if T1 is None: # random shuffle of timepoints
+    _, n, m = Y.shape
+    nt_train = int(round(m / 2)) if nt_train is None else nt_train
+    nn_train = int(round(n / 2)) if nn_train is None else nn_train
+
+    if T1 is None:  # random shuffle of timepoints
         T1 = np.random.permutation(np.arange(m))[:nt_train]
-    if N1 is None: # random shuffle of neurons
+    if N1 is None:  # random shuffle of neurons
         N1 = np.random.permutation(np.arange(n))[:nn_train]
     split = {'Y': Y, 'N1': N1, 'T1': T1}
-    
-    train_ps1 = update_params(train_ps, batch_pool = T1)
-    
+
+    train_ps1 = update_params(train_ps, batch_pool=T1)
+
     #print(Y.shape, mod.lat_dist.prms[0].shape, mod.lat_dist.prms[1].shape)
-    
-    _ = train_model(mod, Y, device, train_ps1)
-    
+
+    train_model(mod, Y, device, train_ps1)
+
     ### construct a mask for some of the time points ####
     def mask_Ts(grad):
         ''' used to 'mask' some gradients for cv'''
         grad[:, T1, ...] *= 0
         return grad
-    train_ps2 = update_params(train_ps, neuron_idxs = N1, mask_Ts = mask_Ts)
-    
-    
-    for p in mod.parameters(): #no gradients for the remaining parameters
-        p.requires_grad = False
-    for p in mod.lat_dist.parameters(): #only gradients for the latent distribution
-        p.requires_grad = True
-    
-    _ = train_model(mod, Y, device, train_ps2)
-    
-    if test:
-        _ = test_cv(mod, split, device, n_mc = train_ps['n_mc'], Print = True)
-        
-    return mod, split
-        
 
-def test_cv(mod, split, device, n_mc = 32, Print = False):
+    train_ps2 = update_params(train_ps, neuron_idxs=N1, mask_Ts=mask_Ts)
+
+    for p in mod.parameters():  #no gradients for the remaining parameters
+        p.requires_grad = False
+    for p in mod.lat_dist.parameters(
+    ):  #only gradients for the latent distribution
+        p.requires_grad = True
+
+    _ = train_model(mod, Y, device, train_ps2)
+
+    if test:
+        _ = test_cv(mod, split, device, n_mc=train_ps['n_mc'], Print=True)
+
+    return mod, split
+
+
+def test_cv(mod, split, device, n_mc=32, Print=False):
     Y, T1, N1 = split['Y'], split['T1'], split['N1']
     n_samples, n, m = Y.shape
-    
+
     ##### assess the CV quality ####
     T2, N2 = not_in(np.arange(m), T1), not_in(np.arange(n), N1)
 
     #generate prediction for held out data#
-    
-    Ytest = Y[:, N2, :][..., T2] #(ntrial x N2 x T2)
-    latents = mod.lat_dist.prms[0].detach()[:, T2, ...] #latent means (ntrial, T2, d)
-    query = latents.transpose(-1,-2) #(ntrial, d, m)
-    Ypred, var = mod.svgp.predict(query[None, ...], False)
-    Ypred = Ypred.detach().cpu().numpy()[0][:, N2, :] #(ntrial, N2, T2)
-    MSE = np.mean((Ypred - Ytest)**2)
-    
-    var_cap = 1-np.var(Ytest - Ypred)/np.var(Ytest)
 
+    Ytest = Y[:, N2, :][..., T2]  #(ntrial x N2 x T2)
+    latents = mod.lat_dist.prms[0].detach()[:, T2,
+                                            ...]  #latent means (ntrial, T2, d)
+    query = latents.transpose(-1, -2)  #(ntrial, d, m)
+    Ypred, var = mod.svgp.predict(query[None, ...], False)
+    Ypred = Ypred.detach().cpu().numpy()[0][:, N2, :]  #(ntrial, N2, T2)
+    MSE = np.mean((Ypred - Ytest)**2)
+
+    var_cap = 1 - np.var(Ytest - Ypred) / np.var(Ytest)
 
     ### compute crossvalidated log likelihood ###
     #(n_mc, n_samples, n), (n_mc, n_samples)
-    svgp_elbo, kl = mod.elbo(torch.tensor(Y).to(device), n_mc, batch_idxs=T2, neuron_idxs = N2)
-    
-    svgp_elbo = svgp_elbo.sum(-1).sum(-1) #(n_mc)
+    svgp_elbo, kl = mod.elbo(torch.tensor(Y).to(device),
+                             n_mc,
+                             batch_idxs=T2,
+                             neuron_idxs=N2)
+
+    svgp_elbo = svgp_elbo.sum(-1).sum(-1)  #(n_mc)
     LLs = svgp_elbo - kl.sum(-1)  # LL for each batch (n_mc, )
     LL = (torch.logsumexp(LLs, 0) - np.log(n_mc)).detach().cpu().numpy()
-    LL = LL/(len(T2)*len(N2)*n_samples)
-    
+    LL = LL / (len(T2) * len(N2) * n_samples)
+
     if Print:
         print('LL', LL)
         print('var_cap', var_cap)
-        print('MSE', MSE, np.sqrt(np.mean(np.var(Ytest, axis = -1))))
-    
+        print('MSE', MSE, np.sqrt(np.mean(np.var(Ytest, axis=-1))))
+
     return MSE, LL, var_cap
-    
-    

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -43,7 +43,6 @@ def train_model(mod, Y, device, params):
                                       print_every=params['print_every'],
                                       batch_size=params['batch_size'],
                                       stop=params['callback'],
-                                      ts=params['ts'],
                                       batch_pool=params['batch_pool'],
                                       neuron_idxs=params['neuron_idxs'],
                                       mask_Ts=params['mask_Ts']),

--- a/mgplvm/kernels.py
+++ b/mgplvm/kernels.py
@@ -91,7 +91,7 @@ class QuadExpBase(Kernel):
                 torch.tensor(alpha, dtype=torch.get_default_dtype()))
         elif Y is not None:
             alpha = inv_softplus(
-                torch.tensor(np.mean(np.mean(Y**2, axis=-1), axis=0)).sqrt())
+                torch.tensor(np.mean(Y**2, axis=(0, -1))).sqrt())
         else:
             alpha = inv_softplus(torch.ones(n, ))
 

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -265,7 +265,8 @@ class NegativeBinomial(Likelihood):
         locs = self.inv_link(torch.sqrt(2. * fvar) * locs +
                              fmu) * self.binsize  #coordinate transform
         #print(total_count.shape, locs.shape)
-        lp = self.log_prob(total_count, locs, y)  #(n_mc x n_samples x n x m, n_gh)
+        lp = self.log_prob(total_count, locs,
+                           y)  #(n_mc x n_samples x n x m, n_gh)
 
         #print(lp.shape, ws.shape, (lp * ws).shape)
         return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-1)

--- a/mgplvm/lpriors/common.py
+++ b/mgplvm/lpriors/common.py
@@ -34,7 +34,7 @@ class Uniform(Lprior):
         '''
         super().__init__(manif)
 
-    def forward(self, g: Tensor, ts=None):
+    def forward(self, g: Tensor, batch_idxs=None):
         lp = self.manif.lprior(g)  #(n_b, n_samples, m)
         return lp.to(g.device).sum(-1)  #(n_b, n_samples)
 
@@ -55,7 +55,7 @@ class Null(Lprior):
         '''
         super().__init__(manif)
 
-    def forward(self, g: Tensor, ts=None):
+    def forward(self, g: Tensor, batch_idxs=None):
         '''
         g: (n_b x mx x d)
         output: (n_b)
@@ -102,7 +102,7 @@ class Gaussian(Lprior):
             self.gamma)
         return gamma
 
-    def forward(self, g, ts=None, kmax=5):
+    def forward(self, g, batch_idxs=None, kmax=5):
         '''
         g: (n_b x mx x d)
         output: (n_b)
@@ -160,7 +160,7 @@ class Brownian(Lprior):
         brownian_c = self.brownian_c
         return brownian_c, brownian_eta
 
-    def forward(self, g, ts=None):
+    def forward(self, g, batch_idxs=None):
         brownian_c, brownian_eta = self.prms
         ginv = self.manif.inverse(g)
         dg = self.manif.gmul(ginv[..., 0:-1, :], g[..., 1:, :])
@@ -220,7 +220,7 @@ class ARP(Lprior):
     def prms(self):
         return self.ar_c, self.ar_phi, torch.square(self.ar_eta)
 
-    def forward(self, g, ts=None):
+    def forward(self, g, batch_idxs=None):
         p = self.p
         ar_c, ar_phi, ar_eta = self.prms
         ginv = self.manif.inverse(g)  # n_b x n_samplex mx x d2 (on group)

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -51,7 +51,7 @@ class GP(LpriorEuclid):
         sigma_n = self.svgp.likelihood.prms
         return q_mu, q_sqrt, z, sigma_n
 
-    def forward(self, x, ts, scale = 1.):
+    def forward(self, x, ts):
         '''
         x is a latent of shape (n_mc x n_samples x mx x d)
         ts is the corresponding timepoints of shape (n_samples x mx)
@@ -61,7 +61,12 @@ class GP(LpriorEuclid):
         x = x.permute(1, 0, 3, 2).reshape(n_samples, -1, T)
 
         # shape (d, n_mc)
-        svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, n_samples, 1, -1), scale = scale)
+        #svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, n_samples, 1, -1))
+        
+        #svgp_lik, svgp_kl = self.svgp.elbo(1, x, ts.reshape(1, n_samples, 1, -1))
+        #elbo = svgp_lik - n_b/m svgp_kl
+        #return reshaped elbo
+        
         print(svgp_elbo.shape)
         return svgp_elbo.sum(-2)  #sum over dimensions
 

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -70,7 +70,6 @@ class GP(LpriorEuclid):
                                            ts.reshape(1, n_samples, 1, -1))
         # Here, we need to rescale the KL term so that it is per batch
         # as the inducing points are shared across the full batch
-        svgp_kl = (batch_size / m) * svgp_kl
         elbo = svgp_lik - ((batch_size / m) * svgp_kl)
         return elbo.reshape(n_mc, d).sum(-1)  #sum over dimensions
 

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -63,16 +63,16 @@ class GP(LpriorEuclid):
         ts = ts.to(x.device)
         n_mc, n_samples, T, d = x.shape
         # x now has shape (n_samples, n_mc*d, T)
-        x = x.permute(1, 0, 3, 2).reshape(n_samples, -1, T)
+        x = x.permute(1, 0, 3, 2).reshape(n_samples, n_mc * d, T)
 
-        # (1, n_samples, n_mc . d) (1, n_mc . d)
+        # (1, n_mc . d) (n_mc . d)
         svgp_lik, svgp_kl = self.svgp.elbo(1, x,
                                            ts.reshape(1, n_samples, 1, -1))
         # Here, we need to rescale the KL term so that it is per batch
         # as the inducing points are shared across the full batch
         svgp_kl = (batch_size / m) * svgp_kl
         elbo = svgp_lik - ((batch_size / m) * svgp_kl)
-        return elbo.reshape(n_samples, n_mc, d).sum(-1).T  #sum over dimensions
+        return elbo.reshape(n_mc, d).sum(-1)  #sum over dimensions
 
     @property
     def msg(self):

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -26,6 +26,7 @@ class GP(LpriorEuclid):
     def __init__(self,
                  manif: Manifold,
                  kernel: Kernel,
+                 ts: torch.Tensor,
                  n_z: Optional[int] = 20,
                  tmax: Optional[int] = 1):
         '''
@@ -40,6 +41,7 @@ class GP(LpriorEuclid):
         zinit = torch.linspace(0., tmax, n_z).reshape(1, 1, n_z)
         #separate inducing points for each latent dimension
         z = InducingPoints(d, 1, n_z, z=zinit.repeat(d, 1, 1))
+        self.ts = ts
         lik = Gaussian(
             d, variance=np.square(0.2), learn_sigma=False
         )  #.to(kernel.alpha.device) #consider fixing this to a small value as in GPFA
@@ -51,11 +53,13 @@ class GP(LpriorEuclid):
         sigma_n = self.svgp.likelihood.prms
         return q_mu, q_sqrt, z, sigma_n
 
-    def forward(self, x, ts):
+    def forward(self, x, batch_idxs=None):
         '''
         x is a latent of shape (n_mc x n_samples x mx x d)
         ts is the corresponding timepoints of shape (n_samples x mx)
         '''
+        ts = self.ts if batch_idxs is None else self.ts[batch_idxs]
+        ts = ts.to(x.device)
         n_mc, n_samples, T, d = x.shape
         # x now has shape (n_samples, n_mc*d, mx)
         x = x.permute(1, 0, 3, 2).reshape(n_samples, -1, T)

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -51,18 +51,19 @@ class GP(LpriorEuclid):
         sigma_n = self.svgp.likelihood.prms
         return q_mu, q_sqrt, z, sigma_n
 
-    def forward(self, x, ts):
+    def forward(self, x, ts, scale = 1.):
         '''
         x is a latent of shape (n_mc x n_samples x mx x d)
         ts is the corresponding timepoints of shape (n_samples x mx)
         '''
         n_mc, n_samples, T, d = x.shape
-        # x now has shape (n_samples, n_mc, d, mx)
+        # x now has shape (n_samples, n_mc*d, mx)
         x = x.permute(1, 0, 3, 2).reshape(n_samples, -1, T)
 
-        # shape (n_samples, n_mc . d)
-        svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, n_samples, 1, -1))
-        return svgp_elbo.reshape(n_samples, n_mc, d).sum(-1).T
+        # shape (d, n_mc)
+        svgp_elbo = self.svgp.elbo(1, x, ts.reshape(1, n_samples, 1, -1), scale = scale)
+        print(svgp_elbo.shape)
+        return svgp_elbo.sum(-2)  #sum over dimensions
 
     @property
     def msg(self):

--- a/mgplvm/lpriors/torus.py
+++ b/mgplvm/lpriors/torus.py
@@ -32,7 +32,7 @@ class VonMises(LpriorTorus):
         return dists.transform_to(dists.constraints.greater_than_eq(0))(
             self.concentration)
 
-    def forward(self, g):
+    def forward(self, g, batch_idxs=None):
         concentration = self.prms
         ginv = self.manif.inverse(g)
         dg = self.manif.gmul(ginv[..., 0:-1, :], g[..., 1:, :])
@@ -93,7 +93,7 @@ class IARP(LpriorTorus):
         mu = self.link(self.mu)
         return mu, self.phi, concentration
 
-    def forward(self, g):
+    def forward(self, g, batch_idxs=None):
         mu, phi, concentration = self.prms
         p = self.p
         g = (g - mu) % (np.pi * 2)  # make sure it's
@@ -154,7 +154,7 @@ class LARP(LpriorTorus):
         mu = self.link(self.mu)
         return mu, self.phi, torch.square(self.eta)
 
-    def forward(self, g):
+    def forward(self, g, batch_idxs=None):
         mu, phi, eta = self.prms
         p = self.p
         g = (g - mu) % (np.pi * 2)  # make sure it's on the circle

--- a/mgplvm/models/sgplvm.py
+++ b/mgplvm/models/sgplvm.py
@@ -70,7 +70,7 @@ class SgpLvm(nn.Module):
         Parameters
         ----------
         data : Tensor
-            data with dimensionality (n x m x n_samples)
+            data with dimensionality (n_samples x n x m)
         n_b : int
             batch size
         kmax : int
@@ -91,11 +91,14 @@ class SgpLvm(nn.Module):
         ----
         ELBO of the model per batch is [ sgp_elbo - kl ]
         """
-        _, _, n_samples = data.shape
+        #_, _, n_samples = data.shape
+        n_samples, n, m = data.shape
+        
         q = self.rdist()  # return reference distribution
 
         # sample a batch with dims: (n_b x m x d)
         x = q.rsample(torch.Size([n_b]))
+        print('xshape', x.shape)
         # compute entropy (n_b x m)
         lq = self.manif.log_q(q.log_prob, x, self.manif.d, kmax=kmax)
 

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -109,6 +109,8 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         #(n_mc, n_samles, n)
         lik = self.likelihood.variational_expectation(y, f_mean, f_var)
+        #(n_mc, n)
+        lik = lik.sum(-2)
 
         return lik, prior_kl
 

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -81,7 +81,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         return kl_divergence(q, prior)
 
-    def elbo(self, n_mc: int, y: Tensor, x: Tensor, scale: float = 1.) -> Tuple[Tensor, Tensor]:
+    def elbo(self, n_mc: int, y: Tensor, x: Tensor) -> Tuple[Tensor, Tensor]:
         """
         Parameters
         ----------
@@ -91,8 +91,6 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
             data tensor with dimensions (n_samples x n x m)
         x : Tensor (single kernel) or Tensor list (product kernels)
             input tensor(s) with dimensions (n_mc x n_samples x d x m)
-        scale: Optional[int]
-            scale factor for the prior term; n_batch/m
 
         Returns
         -------
@@ -111,12 +109,8 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         #(n_mc, n_samles, n)
         lik = self.likelihood.variational_expectation(y, f_mean, f_var)
-        lik = lik.sum(-2) #n_mc x n -- sum over samples (similar to how we sum over conditions)
-        
-        svgp_elbo = lik - scale*prior_kl # (n_mc x n) and (1 x n); broadcast prior over MC samples
-        return svgp_elbo #(n_mc x n)
-    
-        #return lik, prior_kl
+
+        return lik, prior_kl
 
     def tuning(self, query, n_b=1000, square=False):
         '''

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -115,6 +115,8 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         
         svgp_elbo = lik - scale*prior_kl # (n_mc x n) and (1 x n); broadcast prior over MC samples
         return svgp_elbo #(n_mc x n)
+    
+        #return lik, prior_kl
 
     def tuning(self, query, n_b=1000, square=False):
         '''

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -146,8 +146,8 @@ class SvgpLvm(nn.Module):
                             batch_idxs=batch_idxs,
                             neuron_idxs=neuron_idxs)
         #sum over neurons and number of samples, mean over  MC samples
-        lik = lik.sum(-1).sum(-1).mean()
-        kl = kl.sum(-1).mean()
+        lik = lik.sum(-1).mean()
+        kl = kl.mean()
 
         return lik, kl  #mean across batches, sum across everything else
 

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -102,14 +102,14 @@ class SvgpLvm(nn.Module):
         # lq is shape (n_mc x n_samples x m)
 
         data = data if batch_idxs is None else data[:, :, batch_idxs]
-        scale = 1. if batch_idxs is None else len(batch_idxs)/m #scale the svgp prior for unbiased estimator
         ts = ts if (ts is None or batch_idxs is None) else ts[batch_idxs]
+        batch_size = m if batch_idxs is None else len(batch_idxs) #batch size
 
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)
         # and so we need to permute [ g ] to have the right dimensions
-
+        #scale the svgp prior by batch_size/m for unbiased estimator
         #(n_mc x n)
-        svgp_elbo = self.svgp.elbo(n_mc, data, g.transpose(-1, -2), scale = scale)
+        svgp_elbo = self.svgp.elbo(n_mc, data, g.transpose(-1, -2), scale = batch_size/m)
         if neuron_idxs is not None:
             svgp_elbo = svgp_elbo[..., neuron_idxs]
             
@@ -118,6 +118,18 @@ class SvgpLvm(nn.Module):
         kl = lq.sum(-1) - prior  #(n_mc, n_samples) (sum q(g) over conditions)
         kl = kl.sum(-1) #sum prior KL over samples (basically structured conditions)
 
+        #lik, svgp_kl = self.svgp.elbo(n_mc, data, g.transpose(-1, -2))
+        #ELBO = m/nb * svgp_lik - svgp_kl - m/nb * KL_LVM (sum over m, n_samples)
+        
+        
+        ### ELBO = m/nb * svgp_lik - svgp_kl + m/nb prior_lik - prior_kl
+        
+        
+        #return (m/nb * svgp_lik - svgp_kl), (m/n_b * KL)
+        
+        ### print normalized ELBO: ELBO / (n*m*n_samples)
+        
+        
         return svgp_elbo, kl
 
     def forward(self,
@@ -160,7 +172,7 @@ class SvgpLvm(nn.Module):
 
         return svgp_elbo, kl  #mean across batches, sum across everything else
 
-    def calc_LL(self, data, n_mc, kmax=5, batch_idxs=None, ts=None):
+    def calc_LL(self, data, n_mc, kmax=5, ts=None):
         """
         Parameters
         ----------
@@ -190,6 +202,7 @@ class SvgpLvm(nn.Module):
         print(svgp_elbo.shape, kl.shape)
         svgp_elbo = svgp_elbo.sum(-1)  #(n_mc)
         LLs = svgp_elbo - kl  # LL for each batch (n_mc)
+        
         print(LLs.shape)
         LL = (torch.logsumexp(LLs, 0) - np.log(n_mc))/np.prod(data.shape)
 

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -61,13 +61,7 @@ class SvgpLvm(nn.Module):
         self.lat_dist = lat_dist
         self.lprior = lprior
 
-    def elbo(self,
-             data,
-             n_mc,
-             kmax=5,
-             batch_idxs=None,
-             ts=None,
-             neuron_idxs=None):
+    def elbo(self, data, n_mc, kmax=5, batch_idxs=None, neuron_idxs=None):
         """
         Parameters
         ----------
@@ -102,8 +96,6 @@ class SvgpLvm(nn.Module):
         # lq is shape (n_mc x n_samples x m)
 
         data = data if batch_idxs is None else data[:, :, batch_idxs]
-        ts = ts if (ts is None or batch_idxs is None) else ts[batch_idxs]
-        batch_size = m if batch_idxs is None else len(batch_idxs) #batch size
 
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)
         # and so we need to permute [ g ] to have the right dimensions
@@ -132,18 +124,12 @@ class SvgpLvm(nn.Module):
         
         return svgp_elbo, kl
 
-    def forward(self,
-                data,
-                n_mc,
-                kmax=5,
-                batch_idxs=None,
-                ts=None,
-                neuron_idxs=None):
+    def forward(self, data, n_mc, kmax=5, batch_idxs=None, neuron_idxs=None):
         """
         Parameters
         ----------
         data : Tensor
-            data with dimensionality (n_samples, n x m)
+            data with dimensionality (n_samples x n x m)
         n_mc : int
             number of MC samples
         kmax : int
@@ -164,7 +150,6 @@ class SvgpLvm(nn.Module):
                                   n_mc,
                                   kmax=kmax,
                                   batch_idxs=batch_idxs,
-                                  ts=ts,
                                   neuron_idxs=neuron_idxs)
         #sum over neurons, mean over  MC samples
         svgp_elbo = svgp_elbo.sum(-1).mean()
@@ -172,7 +157,7 @@ class SvgpLvm(nn.Module):
 
         return svgp_elbo, kl  #mean across batches, sum across everything else
 
-    def calc_LL(self, data, n_mc, kmax=5, ts=None):
+    def calc_LL(self, data, n_mc, kmax=5):
         """
         Parameters
         ----------
@@ -197,8 +182,7 @@ class SvgpLvm(nn.Module):
         svgp_elbo, kl = self.elbo(data,
                                   n_mc,
                                   kmax=kmax,
-                                  batch_idxs=batch_idxs,
-                                  ts=ts)
+                                  batch_idxs=batch_idxs)
         print(svgp_elbo.shape, kl.shape)
         svgp_elbo = svgp_elbo.sum(-1)  #(n_mc)
         LLs = svgp_elbo - kl  # LL for each batch (n_mc)

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -173,5 +173,6 @@ def fit(Y,
         scheduler.step()
         print_progress(model, n, m, data.shape[0], i, loss_val, kl_val, svgp_elbo_val,
                        print_every, data, batch_idxs)
+        
 
     return model

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -120,9 +120,10 @@ def fit(Y,
         return 1 - np.exp(-x / (3 * burnin))
 
     if len(Y.shape) > 2:
-        _, n, m = Y.shape  # samples, neurons, conditions
+        n_samples, n, m = Y.shape  # samples, neurons, conditions
     else:
         n, m = Y.shape  # neuron x conditions
+        n_samples = 1
     data = torch.tensor(Y, dtype=torch.get_default_dtype()).to(device)
     data_size = m if batch_pool is None else len(batch_pool)  #total conditions
     n = n if neuron_idxs is None else len(neuron_idxs)
@@ -144,8 +145,6 @@ def fit(Y,
                                          data_size,
                                          batch_pool=batch_pool,
                                          batch_size=batch_size)
-        m = len(batch_idxs)  #use for printing likelihoods etc.
-
         svgp_elbo, kl = model(data,
                               n_mc,
                               batch_idxs=batch_idxs,
@@ -161,5 +160,5 @@ def fit(Y,
         loss.backward()
         opt.step()
         scheduler.step()
-        print_progress(model, n, m, data.shape[0], i, loss_val, kl_val,
+        print_progress(model, n, m, n_samples, i, loss_val, kl_val,
                        svgp_elbo_val, print_every, data, batch_idxs)

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -22,14 +22,15 @@ def test_cv_runs():
     m = 10  # number of conditions / time points
     n_z = 6  # number of inducing points
     n_samples = 1  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25, n_samples=n_samples)
+    gen = syndata.Gen(syndata.Euclid(d),
+                      n,
+                      m,
+                      variability=0.25,
+                      n_samples=n_samples)
     Y = gen.gen_data()
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
-    lat_dist = mgplvm.rdist.ReLie(manif,
-                                  m,
-                                  n_samples,
-                                  diagonal=False)
+    lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, diagonal=False)
     kernel = kernels.QuadExp(n, manif.distance)
     lik = likelihoods.Gaussian(n)
     lprior = mgplvm.lpriors.Uniform(manif)
@@ -38,10 +39,13 @@ def test_cv_runs():
                          whiten=True).to(device)
 
     ### run cv ###
-    train_ps = mgplvm.crossval.training_params(lrate = 5e-2, burnin = 20, ts=None, batch_size = None,
-                                                  max_steps = 10, n_mc = 32)
-    mod, split = mgplvm.crossval.train_cv(mod,Y,device,train_ps,test = False)
-    _ = mgplvm.crossval.test_cv(mod, split, device, Print = True)
+    train_ps = mgplvm.crossval.training_params(lrate=5e-2,
+                                               burnin=20,
+                                               batch_size=None,
+                                               max_steps=10,
+                                               n_mc=32)
+    mod, split = mgplvm.crossval.train_cv(mod, Y, device, train_ps, test=False)
+    _ = mgplvm.crossval.test_cv(mod, split, device, Print=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -22,7 +22,11 @@ def test_likelihood_runs():
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25, n_samples=n_samples)
+    gen = syndata.Gen(syndata.Euclid(d),
+                      n,
+                      m,
+                      variability=0.25,
+                      n_samples=n_samples)
     Y = gen.gen_data()
     Y = np.round(Y - np.amin(Y))
     print(Y.shape)
@@ -46,15 +50,15 @@ def test_likelihood_runs():
                              whiten=True).to(device)
 
         # train model
-        trained_model = optimisers.svgp.fit(Y,
-                                            mod,
-                                            device,
-                                            optimizer=optim.Adam,
-                                            max_steps=5,
-                                            burnin=5 / 2E-2,
-                                            n_mc=64,
-                                            lrate=2E-2,
-                                            print_every=1000)
+        optimisers.svgp.fit(Y,
+                            mod,
+                            device,
+                            optimizer=optim.Adam,
+                            max_steps=5,
+                            burnin=5 / 2E-2,
+                            n_mc=64,
+                            lrate=2E-2,
+                            print_every=1000)
 
         ### test burda log likelihood ###
         LL = mod.calc_LL(torch.tensor(Y).to(device), 128)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,7 @@ def test_svgp_runs():
     ### test burda log likelihood ###
     LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
     svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
-    elbo = (svgp_elbo - kl) / np.prod(Y.shape)
+    elbo = (svgp_elbo - kl).data.cpu().numpy() / np.prod(Y.shape)
 
     assert elbo < LL
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,14 +22,15 @@ def test_svgp_runs():
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d), n, m, variability=0.25, n_samples=n_samples)
+    gen = syndata.Gen(syndata.Euclid(d),
+                      n,
+                      m,
+                      variability=0.25,
+                      n_samples=n_samples)
     Y = gen.gen_data()
     # specify manifold, kernel and rdist
     manif = Euclid(m, d)
-    lat_dist = mgplvm.rdist.ReLie(manif,
-                                  m,
-                                  n_samples,
-                                  diagonal=False)
+    lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, diagonal=False)
     kernel = kernels.QuadExp(n, manif.distance)
     lik = likelihoods.Gaussian(n)
     lprior = mgplvm.lpriors.Uniform(manif)
@@ -38,23 +39,23 @@ def test_svgp_runs():
                          whiten=True).to(device)
 
     # train model
-    trained_model = optimisers.svgp.fit(Y,
-                                        mod,
-                                        device,
-                                        optimizer=optim.Adam,
-                                        max_steps=5,
-                                        burnin=5 / 2E-2,
-                                        n_mc=64,
-                                        lrate=2E-2,
-                                        print_every=1000)
+    optimisers.svgp.fit(Y,
+                        mod,
+                        device,
+                        optimizer=optim.Adam,
+                        max_steps=5,
+                        burnin=5 / 2E-2,
+                        n_mc=64,
+                        lrate=2E-2,
+                        print_every=1000)
 
     ### test burda log likelihood ###
     LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
     svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
     elbo = (svgp_elbo - kl) / np.prod(Y.shape)
-    
+
     assert elbo < LL
-    
+
     #### test that batching works ####
     trained_model = optimisers.svgp.fit(Y,
                                         mod,
@@ -62,7 +63,8 @@ def test_svgp_runs():
                                         optimizer=optim.Adam,
                                         max_steps=5,
                                         n_mc=64,
-                                        batch_size = int(np.round(m/2, 0)))
+                                        batch_size=int(np.round(m / 2, 0)))
+
 
 if __name__ == '__main__':
     test_svgp_runs()

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -2,75 +2,70 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from torch import optim
-import mgplvm
-from mgplvm import manifolds, rdist, kernels, likelihoods, lpriors, models, optimisers
+import mgplvm as mgp
 torch.set_default_dtype(torch.float64)
-device = mgplvm.utils.get_device()
+device = mgp.utils.get_device()
 
 
 def test_GP_prior():
-    device = mgplvm.utils.get_device("cuda")  # get_device("cpu")
+    device = mgp.utils.get_device("cuda")  # get_device("cpu")
     d = 1  # dims of latent space
     n = 100  # number of neurons
     m = 250  # number of conditions / time points
     n_z = 15  # number of inducing points
     n_samples = 2  # number of samples
     l = 0.55 * np.sqrt(d)
-    gen = mgplvm.syndata.Gen(mgplvm.syndata.Euclid(d),
-                             n,
-                             m,
-                             variability=0.15,
-                             l=l,
-                             sigma=0.8,
-                             beta=0.1,
-                             n_samples=n_samples)
+    gen = mgp.syndata.Gen(mgp.syndata.Euclid(d),
+                          n,
+                          m,
+                          variability=0.15,
+                          l=l,
+                          sigma=0.8,
+                          beta=0.1,
+                          n_samples=n_samples)
     sig0 = 1.5
     Y = gen.gen_data(ell=25, sig=1)
     # specify manifold, kernel and rdist
-    manif = mgplvm.manifolds.Euclid(m, d)
+    manif = mgp.manifolds.Euclid(m, d)
     alpha = np.mean(np.std(Y, axis=-1), axis=0)
     sigma = np.mean(np.std(Y, axis=-1), axis=0)  # initialize noise
-    kernel = mgplvm.kernels.QuadExp(n, manif.distance, alpha=alpha)
+    kernel = mgp.kernels.QuadExp(n, manif.distance, alpha=alpha)
 
-    #lat_dist = mgplvm.rdist.MVN(m, d, sigma=sig0)
-    lat_dist = mgplvm.rdist.ReLie(manif,
-                                  m,
-                                  n_samples,
-                                  sigma=sig0,
-                                  initialization='random',
-                                  Y=Y)
+    #lat_dist = mgp.rdist.MVN(m, d, sigma=sig0)
+    lat_dist = mgp.rdist.ReLie(manif,
+                               m,
+                               n_samples,
+                               sigma=sig0,
+                               initialization='random',
+                               Y=Y)
 
     ###construct prior
-    lprior_kernel = mgplvm.kernels.QuadExp(d,
-                                           manif.distance,
-                                           learn_alpha=False)
-    lprior = mgplvm.lpriors.GP(manif, lprior_kernel, n_z=20, tmax=m)
+    lprior_kernel = mgp.kernels.QuadExp(d, manif.distance, learn_alpha=False)
+    ts = torch.arange(m).to(device)[None, ...].repeat(n_samples, 1)
+    lprior = mgp.lpriors.GP(manif, lprior_kernel, n_z=20, ts=ts, tmax=m)
     #lprior = lpriors.Gaussian(manif)
 
     # generate model
-    likelihood = mgplvm.likelihoods.Gaussian(n, variance=np.square(sigma))
+    likelihood = mgp.likelihoods.Gaussian(n, variance=np.square(sigma))
     z = manif.inducing_points(n, n_z)
-    mod = mgplvm.models.SvgpLvm(n, z, kernel, likelihood, lat_dist,
-                                lprior).to(device)
+    mod = mgp.models.SvgpLvm(n, z, kernel, likelihood, lat_dist,
+                             lprior).to(device)
 
     ### test that training runs ###
-    ts = torch.arange(m).to(device)[None, ...].repeat(n_samples, 1)
     n_mc = 64
-    trained_mod = mgplvm.optimisers.svgp.fit(Y,
-                                             mod,
-                                             device,
-                                             optimizer=optim.Adam,
-                                             max_steps=5,
-                                             burnin=100,
-                                             n_mc=n_mc,
-                                             lrate=10E-2,
-                                             print_every=50,
-                                             ts=ts)
+    mgp.optimisers.svgp.fit(Y,
+                            mod,
+                            device,
+                            optimizer=optim.Adam,
+                            n_mc=n_mc,
+                            max_steps=5,
+                            burnin=100,
+                            lrate=10E-2,
+                            print_every=50)
 
     ### test that two ways of computing the prior agree ###
     data = torch.tensor(Y).to(device)
     g, lq = mod.lat_dist.sample(torch.Size([n_mc]), data, None)
-
     x = g  #input to prior
 
     #### naive computation ####
@@ -98,38 +93,37 @@ def test_ARP_runs():
     n_samples = 2
     Y = np.random.normal(0, 1, (n_samples, n, m))
     for i, manif_type in enumerate(
-        [manifolds.Euclid, manifolds.Torus, manifolds.So3]):
+        [mgp.manifolds.Euclid, mgp.manifolds.Torus, mgp.manifolds.So3]):
         manif = manif_type(m, d)
         print(manif.name)
-        lat_dist = mgplvm.rdist.ReLie(
-            manif,
-            m,
-            n_samples,
-            sigma=0.4,
-            diagonal=(True if i in [0, 1] else False))
-        kernel = mgplvm.kernels.QuadExp(n, manif.distance, Y=Y)
+        lat_dist = mgp.rdist.ReLie(manif,
+                                   m,
+                                   n_samples,
+                                   sigma=0.4,
+                                   diagonal=(True if i in [0, 1] else False))
+        kernel = mgp.kernels.QuadExp(n, manif.distance, Y=Y)
         # generate model
-        lik = mgplvm.likelihoods.Gaussian(n)
-        lprior = mgplvm.lpriors.ARP(p,
-                                    manif,
-                                    diagonal=(True if i in [0, 1] else False))
+        lik = mgp.likelihoods.Gaussian(n)
+        lprior = mgp.lpriors.ARP(p,
+                                 manif,
+                                 diagonal=(True if i in [0, 1] else False))
         z = manif.inducing_points(n, n_z)
-        mod = mgplvm.models.SvgpLvm(n,
-                                    z,
-                                    kernel,
-                                    lik,
-                                    lat_dist,
-                                    lprior,
-                                    whiten=True).to(device)
+        mod = mgp.models.SvgpLvm(n,
+                                 z,
+                                 kernel,
+                                 lik,
+                                 lat_dist,
+                                 lprior,
+                                 whiten=True).to(device)
 
         # train model
-        trained_model = optimisers.svgp.fit(Y,
-                                            mod,
-                                            device,
-                                            max_steps=5,
-                                            n_mc=64,
-                                            optimizer=optim.Adam,
-                                            print_every=1000)
+        mgp.optimisers.svgp.fit(Y,
+                                mod,
+                                device,
+                                max_steps=5,
+                                n_mc=64,
+                                optimizer=optim.Adam,
+                                print_every=1000)
 
 
 if __name__ == '__main__':

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -82,7 +82,7 @@ def test_GP_prior():
 
     #### try to batch things ####
     elbo2_b = mod.lprior.svgp.elbo(1, x.transpose(-1, -2), ts)
-    elbo2_b = elbo2_b.sum(-1).sum(-1)
+    elbo2_b = elbo2_b
     print(elbo1_b.shape, elbo2_b.shape)
 
     ### print comparison ###

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -1,0 +1,80 @@
+import numpy as np
+import torch
+from torch import optim
+import mgplvm
+from mgplvm import kernels, rdist, models, optimisers, syndata, likelihoods
+from mgplvm.manifolds import Torus, Euclid, So3
+import matplotlib.pyplot as plt
+torch.set_default_dtype(torch.float64)
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+else:
+    device = torch.device("cpu")
+
+
+def test_trial_structure():
+    """
+    test that svgp runs without explicit check for correctness
+    also test that burda log likelihood runs and is smaller than elbo
+    """
+    d = 1  # dims of latent space
+    n = 8  # number of neurons
+    m = 10  # number of conditions / time points
+    n_z = 5  # number of inducing points
+    n_samples = 2  # number of samples
+    Y = np.random.normal(0, 1, (n_samples, n, m))
+    print(Y.shape)
+    
+    zs = torch.randn((n, d, n_z))
+    sig0 = 0.1
+    
+    # specify manifold, kernel and rdist
+    manif1 = Euclid(m, d)
+    lat_dist1 = mgplvm.rdist.ReLie(manif1,
+                                  m,
+                                  n_samples,
+                                  diagonal=False,
+                                  initialization = 'pca',
+                                  Y = Y,
+                                  sigma = sig0)
+    kernel1 = kernels.QuadExp(n, manif1.distance, Y = Y)
+    lik1 = likelihoods.Gaussian(n)
+    lprior1 = mgplvm.lpriors.Uniform(manif1)
+    z1 = manif1.inducing_points(n, n_z, z = zs)
+    mod1 = models.SvgpLvm(n, z1, kernel1, lik1, lat_dist1, lprior1,
+                         whiten=True).to(device)
+    
+    
+    Y2 = Y.transpose(1,0,2).reshape(n, -1)[None, ...]
+    n_samples2, n2, m2 = Y2.shape
+    print(Y2.shape)
+    manif2 = Euclid(m2, d)
+    lat_dist2 = mgplvm.rdist.ReLie(manif2,
+                                  m2,
+                                  n_samples2,
+                                  diagonal=False,
+                                  initialization = 'pca',
+                                  Y = Y2,
+                                  sigma = sig0)
+    kernel2 = kernels.QuadExp(n2, manif2.distance, Y = Y2)
+    lik2 = likelihoods.Gaussian(n2)
+    lprior2 = mgplvm.lpriors.Uniform(manif2)
+    z2 = manif2.inducing_points(n2, n_z, z = zs)
+    mod2 = models.SvgpLvm(n2, z2, kernel2, lik2, lat_dist2, lprior2,
+                         whiten=True).to(device)
+    
+    print('kernel 1', torch.allclose(mod1.svgp.kernel.prms[0], mod2.svgp.kernel.prms[0]))
+    print('kernel 2', torch.allclose(mod1.svgp.kernel.prms[1], mod2.svgp.kernel.prms[1]))
+    print('svgp 1', torch.allclose(mod1.svgp.prms[0], mod2.svgp.prms[0]))
+    print('svgp 2', torch.allclose(mod1.svgp.prms[1], mod2.svgp.prms[1]))
+    print('svgp 3', torch.allclose(mod1.svgp.prms[2], mod2.svgp.prms[2]))
+    print('mus', torch.allclose(mod1.lat_dist.prms[0].reshape(-1, d), mod2.lat_dist.prms[0].reshape(-1, d)))
+    print('sigs', torch.allclose(mod1.lat_dist.prms[1].reshape(-1, d, d), mod2.lat_dist.prms[1].reshape(-1, d, d)))
+    print('liks', torch.allclose(mod1.svgp.likelihood.prms, mod2.svgp.likelihood.prms))
+    
+    
+    print(mod1.forward(torch.tensor(Y).to(device), 9))
+    print(mod2.forward(torch.tensor(Y2).to(device), 9))
+    
+if __name__ == '__main__':
+    test_trial_structure()

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -72,8 +72,11 @@ def test_trial_structure():
     assert torch.allclose(mod1.lat_dist.prms[1].reshape(-1, d, d), mod2.lat_dist.prms[1].reshape(-1, d, d))
     assert torch.allclose(mod1.svgp.likelihood.prms, mod2.svgp.likelihood.prms)
     
-    nrep = 10
     n_mc = 9
+    print(mod1.forward(torch.tensor(Y).to(device), n_mc))
+    print(mod2.forward(torch.tensor(Y2).to(device), n_mc))
+    
+    nrep = 20
     mod1s, mod2s = [np.zeros(nrep) for i in range(2)]
     for i in range(nrep): #compute the LLs, should be similar
         mod1s[i] = mod1.forward(torch.tensor(Y).to(device), n_mc)[0].detach().cpu().numpy()
@@ -82,8 +85,7 @@ def test_trial_structure():
     print(comp)
     assert comp > 0 #basically check that one version is not consistently lower/higher than the other
     
-    print(mod1.forward(torch.tensor(Y).to(device), n_mc))
-    print(mod2.forward(torch.tensor(Y2).to(device), n_mc))
+    
     
 if __name__ == '__main__':
     test_trial_structure()


### PR DESCRIPTION
In this PR, we fixed a nasty error in `svgp` when we're batching over the "condition" dimension. 
Instead of computing, 
```
elbo = m / n_batch * p(batch |  g) - KL(q(g) || p(g)) 
```
we were computing 
```
elbo = p(batch |  g) - KL(q(g) || p(g)) 
```

This is now fixed.

In this PR, we also made `ts` an attribute of the GP lprior module. This way, we do not need to pass `ts` to `optimise.svgp.fit`, but only pass it to `lpriors.euclidean.GP` 