### PR TITLE
Broken multi-output gp prior

### DIFF
--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -95,8 +95,15 @@ class Gaussian(Likelihood):
         #print(variance.shape)
         ve1 = -0.5 * log2pi * m  #scalar
         ve2 = -0.5 * torch.log(variance) * m  #(n)
-        ve3 = -0.5 * torch.square(y - fmu) / variance[
-            ..., None]  #(n_mc x n_samples x n x m )
+        
+        y = y.reshape(-1, self.n, m)[None, ...] #(n_mc x n_samples x n x m )
+        n_samples = y.shape[1]
+        print(y.shape)
+        print(fmu.shape)
+        fmu = fmu[0].reshape(-1, n_samples, *fmu.shape[2:])
+        #
+        ve3 = -0.5 * torch.square(y - fmu) / variance[..., 
+                None]  #(n_mc x n_samples x n x m )
         ve4 = -0.5 * fvar / variance[..., None]  #(n_mc x n_samples x n x m)
 
         #print(ve1.shape, ve2.shape, ve3.shape, ve4.shape)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -8,8 +8,8 @@ device = mgp.utils.get_device()
 
 
 def test_GP_prior():
-    device = mgp.utils.get_device("cuda")  # get_device("cpu")
-    d = 1  # dims of latent space
+    device = mgp.utils.get_device("cuda:5")  # get_device("cpu")
+    d = 2  # dims of latent space
     n = 100  # number of neurons
     m = 250  # number of conditions / time points
     n_z = 15  # number of inducing points


### PR DESCRIPTION
GP prior seems to be broken when d>1 unless I got the code wrong. But I ran test_priors with d=2 and it didn't run either. I checked the shapes, but couldn't fix it. I don't understand why in euclidean.py we get the reshape x = x.permute(1, 0, 3, 2).reshape(n_samples, n_mc * d, T) in the gp prior, which seems to cause shape mismatch.