### PR TITLE
Added unbiased batching tests for svgplvm and svgp

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -93,6 +93,7 @@ def load_model(params):
                                         learn_alpha=False,
                                         ell=np.ones(d) * m / 10)
         lprior = lpriors.GP(d,
+                            m,
                             n_samples,
                             manif,
                             lprior_kernel,
@@ -124,6 +125,6 @@ def load_model(params):
     #### construct model ####
     device = (mgplvm.utils.get_device()
               if params['device'] is None else params['device'])
-    mod = models.SvgpLvm(n, z, kernel, likelihood, lat_dist, lprior).to(device)
+    mod = models.SvgpLvm(n, m, z, kernel, likelihood, lat_dist, lprior).to(device)
 
     return mod

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -25,18 +25,21 @@ class GP(LpriorEuclid):
 
     def __init__(self,
                  n,
+                 m,
                  n_samples,
                  manif: Manifold,
                  kernel: Kernel,
                  ts: torch.Tensor,
                  n_z: Optional[int] = 20,
-                d = 1):
+                 d=1):
         """
         __init__ method for GP prior class (only works for Euclidean manif)
         Parameters
         ----------
         n : int
             number of output dimensions (i.e. dimensionality of the latent space)
+        m : int
+            number of time points
         n_samples : int 
             number of samples (each with a separate GP posterior)
         manif : mgplvm.manifolds.Manifold
@@ -44,7 +47,7 @@ class GP(LpriorEuclid):
         kernel : mgplvm.kernels.kernel
             kernel used in the prior (does not haave to mtach the p(Y|G) kernel)
         ts: Tensor
-            input timepoints for each sample (n_samples x d2 x 1)
+            input timepoints for each sample (n_samples x d x m)
         n_z : Optional[int]
             number of inducing points used in the GP prior
         d : Optional[int]
@@ -53,6 +56,7 @@ class GP(LpriorEuclid):
         """
         super().__init__(manif)
         self.n = n
+        self.m = m
         self.n_samples = n_samples
         self.d = d
         #1d latent and n_z inducing points
@@ -64,6 +68,7 @@ class GP(LpriorEuclid):
         lik = Gaussian(n, variance=np.square(0.2), learn_sigma=False)
         self.svgp = Svgp(kernel,
                          n,
+                         m,
                          z,
                          lik,
                          whiten=True,
@@ -81,20 +86,21 @@ class GP(LpriorEuclid):
         x is a latent of shape (n_mc x n_samples x mx x d)
         ts is the corresponding timepoints of shape (n_samples x mx)
         '''
-        m = self.ts.shape[0]
+        n_mc, n_samples, m, n = x.shape
+        assert (m == self.m)
         batch_size = m if batch_idxs is None else len(batch_idxs)
-        ts = self.ts if batch_idxs is None else self.ts[batch_idxs]
+        ts = self.ts if batch_idxs is None else self.ts[..., batch_idxs]
         ts = ts.to(x.device)
-        n_mc, n_samples, T, n = x.shape
         assert (n == self.n)
-        # x now has shape (n_mc . n_samples , n, T)
+        # x now has shape (n_mc . n_samples , n, m)
         x = x.transpose(-1, -2)
         ts = ts.reshape(1, n_samples, self.d, -1).repeat(n_mc, 1, 1, 1)
 
         svgp_lik, svgp_kl = self.svgp.elbo(x, ts)
-        elbo = svgp_lik - ((batch_size / m) * svgp_kl)
 
-        # Here, we need to rescale the KL term so that it is per batch
+        # Here, we need to rescale the KL term so that it is over the batch not the full dataset, as that is what is expected in SVGPLVM
+        elbo = (batch_size / m) * (svgp_lik - svgp_kl)
+
         # as the inducing points are shared across the full batch
         return elbo.sum(-1)  #sum over dimensions
 

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -35,7 +35,7 @@ def test_cv_runs():
     lik = likelihoods.Gaussian(n)
     lprior = mgplvm.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
-    mod = models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+    mod = models.SvgpLvm(n, m, z, kernel, lik, lat_dist, lprior,
                          whiten=True).to(device)
 
     ### run cv ###

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -86,7 +86,7 @@ def test_kernels_run():
         lik = likelihoods.Gaussian(n)
         lprior = lpriors.Uniform(manif)
         z = manif.inducing_points(n, n_z)
-        mod = models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+        mod = models.SvgpLvm(n, m, z, kernel, lik, lat_dist, lprior,
                              whiten=True).to(device)
 
         ### test that training runs ###

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -46,7 +46,7 @@ def test_likelihood_runs():
         # generate model
         lprior = mgplvm.lpriors.Uniform(manif)
         z = manif.inducing_points(n, n_z)
-        mod = models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+        mod = models.SvgpLvm(n, m, z, kernel, lik, lat_dist, lprior,
                              whiten=True).to(device)
 
         # train model

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -43,6 +43,7 @@ def test_manifs_runs():
         lprior = mgplvm.lpriors.Uniform(manif)
         z = manif.inducing_points(n, n_z)
         mod = mgplvm.models.SvgpLvm(n,
+                                    m,
                                     z,
                                     kernel,
                                     lik,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,13 @@ def test_svgplvm_LL():
     lik = mgp.likelihoods.Gaussian(n)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
-    mod = mgp.models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+    mod = mgp.models.SvgpLvm(n,
+                             m,
+                             z,
+                             kernel,
+                             lik,
+                             lat_dist,
+                             lprior,
                              whiten=True).to(device)
 
     # train model
@@ -82,7 +88,13 @@ def test_svgplvm_batching():
     lik = mgp.likelihoods.Gaussian(n)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
-    mod = mgp.models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+    mod = mgp.models.SvgpLvm(n,
+                             m,
+                             z,
+                             kernel,
+                             lik,
+                             lat_dist,
+                             lprior,
                              whiten=True).to(device)
 
     data = torch.tensor(Y).to(device)
@@ -127,6 +139,7 @@ def test_svgp_batching():
     z = manif.inducing_points(n, n_z)
     svgp = mgp.models.svgp.Svgp(kernel,
                                 n,
+                                m,
                                 z,
                                 lik,
                                 n_samples=n_samples,
@@ -147,7 +160,7 @@ def test_svgp_batching():
         y = data[..., batch_idxs]
         g = lat_dist.lat_gmu(data, batch_idxs=batch_idxs).transpose(-1, -2)
         svgp_lik, svgp_kl = mod.elbo(y, g)
-        elbo = ((m / batch_size) * svgp_lik) - svgp_kl
+        elbo = svgp_lik - svgp_kl
         return elbo.sum().item()
 
     est_elbos = [for_batch() for _ in range(1000)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,7 @@
 import numpy as np
 import torch
 from torch import optim
-import mgplvm
-from mgplvm import kernels, rdist, models, optimisers, syndata, likelihoods
-from mgplvm.manifolds import Torus, Euclid, So3
+import mgplvm as mgp
 import matplotlib.pyplot as plt
 torch.set_default_dtype(torch.float64)
 if torch.cuda.is_available():
@@ -12,9 +10,9 @@ else:
     device = torch.device("cpu")
 
 
-def test_svgp_runs():
+def test_svgplvm_runs():
     """
-    test that svgp runs without explicit check for correctness
+    test that svgplvm runs without explicit check for correctness
     also test that burda log likelihood runs and is smaller than elbo
     """
     d = 1  # dims of latent space
@@ -22,32 +20,32 @@ def test_svgp_runs():
     m = 10  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 2  # number of samples
-    gen = syndata.Gen(syndata.Euclid(d),
-                      n,
-                      m,
-                      variability=0.25,
-                      n_samples=n_samples)
+    gen = mgp.syndata.Gen(mgp.syndata.Euclid(d),
+                          n,
+                          m,
+                          variability=0.25,
+                          n_samples=n_samples)
     Y = gen.gen_data()
     # specify manifold, kernel and rdist
-    manif = Euclid(m, d)
-    lat_dist = mgplvm.rdist.ReLie(manif, m, n_samples, diagonal=False)
-    kernel = kernels.QuadExp(n, manif.distance)
-    lik = likelihoods.Gaussian(n)
-    lprior = mgplvm.lpriors.Uniform(manif)
+    manif = mgp.manifolds.Euclid(m, d)
+    lat_dist = mgp.rdist.ReLie(manif, m, n_samples, diagonal=False)
+    kernel = mgp.kernels.QuadExp(n, manif.distance)
+    lik = mgp.likelihoods.Gaussian(n)
+    lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
-    mod = models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
-                         whiten=True).to(device)
+    mod = mgp.models.SvgpLvm(n, z, kernel, lik, lat_dist, lprior,
+                             whiten=True).to(device)
 
     # train model
-    optimisers.svgp.fit(Y,
-                        mod,
-                        device,
-                        optimizer=optim.Adam,
-                        max_steps=5,
-                        burnin=5 / 2E-2,
-                        n_mc=64,
-                        lrate=2E-2,
-                        print_every=1000)
+    mgp.optimisers.svgp.fit(Y,
+                            mod,
+                            device,
+                            optimizer=optim.Adam,
+                            max_steps=5,
+                            burnin=5 / 2E-2,
+                            n_mc=64,
+                            lrate=2E-2,
+                            print_every=1000)
 
     ### test burda log likelihood ###
     LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
@@ -56,15 +54,66 @@ def test_svgp_runs():
 
     assert elbo < LL
 
-    #### test that batching works ####
-    trained_model = optimisers.svgp.fit(Y,
-                                        mod,
-                                        device,
-                                        optimizer=optim.Adam,
-                                        max_steps=5,
-                                        n_mc=64,
-                                        batch_size=int(np.round(m / 2, 0)))
+    #### test that batching with svgplvm runs ####
+    trained_model = mgp.optimisers.svgp.fit(Y,
+                                            mod,
+                                            device,
+                                            optimizer=optim.Adam,
+                                            max_steps=5,
+                                            n_mc=64,
+                                            batch_size=int(np.round(m / 2, 0)))
+
+
+def test_svgp_batching():
+    """
+    test that batching with svgp gives an unbiased estimate of  the true elbo
+    """
+    d = 1  # dims of latent space
+    n = 8  # number of neurons
+    m = 100  # number of conditions / time points
+    n_z = 10  # number of inducing points
+    n_samples = 1  # number of samples
+    gen = mgp.syndata.Gen(mgp.syndata.Euclid(d),
+                          n,
+                          m,
+                          variability=0.25,
+                          n_samples=n_samples)
+    Y = gen.gen_data()
+    manif = mgp.manifolds.Euclid(m, d)
+    lat_dist = mgp.rdist.ReLie(manif, m, n_samples, diagonal=False)
+    kernel = mgp.kernels.QuadExp(n, manif.distance)
+    lik = mgp.likelihoods.Gaussian(n)
+    z = manif.inducing_points(n, n_z)
+    svgp = mgp.models.svgp.Svgp(kernel,
+                                n,
+                                z,
+                                lik,
+                                n_samples=n_samples,
+                                whiten=True)
+    mod = svgp.to(device)
+    lat_dist = lat_dist.to(device)
+    data = torch.tensor(Y).to(device)
+    g = lat_dist.lat_gmu(data).transpose(-1, -2)
+
+    # not batched
+    svgp_lik, svgp_kl = mod.elbo(data, g)
+    elbo = (svgp_lik - svgp_kl).sum().item()
+
+    batch_size = 20
+
+    def for_batch():
+        batch_idxs = np.random.choice(m, batch_size, replace=False)
+        y = data[..., batch_idxs]
+        g = lat_dist.lat_gmu(data, batch_idxs=batch_idxs).transpose(-1, -2)
+        svgp_lik, svgp_kl = mod.elbo(y, g)
+        elbo = ((m / batch_size) * svgp_lik) - svgp_kl
+        return elbo.sum().item()
+
+    estimated_elbo = np.mean([for_batch() for _ in range(2000)])
+
+    assert (np.abs((elbo - estimated_elbo) / (elbo + estimated_elbo)) < 1e-4)
 
 
 if __name__ == '__main__':
-    test_svgp_runs()
+    test_svgplvm_runs()
+    test_svgp_batching()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,10 @@ import torch
 from torch import optim
 import mgplvm as mgp
 import matplotlib.pyplot as plt
+
+torch.manual_seed(0)
+np.random.seed(0)
+
 torch.set_default_dtype(torch.float64)
 if torch.cuda.is_available():
     device = torch.device("cuda")

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -45,21 +45,21 @@ def test_GP_prior():
     lprior_kernel = mgp.kernels.QuadExp(d,
                                         lprior_manif.distance,
                                         learn_alpha=False)
-    ts = torch.arange(m).to(device)[None, None, ...].repeat(
-        n_samples, d2, 1)
+    ts = torch.arange(m).to(device)[None, None, ...].repeat(n_samples, d2, 1)
     lprior = mgp.lpriors.GP(d,
+                            m,
                             n_samples,
                             lprior_manif,
                             lprior_kernel,
                             n_z=20,
                             ts=ts,
-                           d = d2)
+                            d=d2)
     #lprior = lpriors.Gaussian(manif)
 
     # generate model
     likelihood = mgp.likelihoods.Gaussian(n, variance=np.square(sigma))
     z = manif.inducing_points(n, n_z)
-    mod = mgp.models.SvgpLvm(n, z, kernel, likelihood, lat_dist,
+    mod = mgp.models.SvgpLvm(n, m, z, kernel, likelihood, lat_dist,
                              lprior).to(device)
 
     ### test that training runs ###
@@ -126,6 +126,7 @@ def test_ARP_runs():
                                  diagonal=(True if i in [0, 1] else False))
         z = manif.inducing_points(n, n_z)
         mod = mgp.models.SvgpLvm(n,
+                                 m,
                                  z,
                                  kernel,
                                  lik,

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -41,7 +41,7 @@ def test_trial_structure():
     lik1 = likelihoods.Gaussian(n)
     lprior1 = mgplvm.lpriors.Uniform(manif1)
     z1 = manif1.inducing_points(n, n_z, z = zs)
-    mod1 = models.SvgpLvm(n, z1, kernel1, lik1, lat_dist1, lprior1,
+    mod1 = models.SvgpLvm(n, m, z1, kernel1, lik1, lat_dist1, lprior1,
                          whiten=True).to(device)
     
     
@@ -60,7 +60,7 @@ def test_trial_structure():
     lik2 = likelihoods.Gaussian(n2)
     lprior2 = mgplvm.lpriors.Uniform(manif2)
     z2 = manif2.inducing_points(n2, n_z, z = zs)
-    mod2 = models.SvgpLvm(n2, z2, kernel2, lik2, lat_dist2, lprior2,
+    mod2 = models.SvgpLvm(n2, m2, z2, kernel2, lik2, lat_dist2, lprior2,
                          whiten=True).to(device)
     
     assert torch.allclose(mod1.svgp.kernel.prms[0], mod2.svgp.kernel.prms[0])


### PR DESCRIPTION
In this PR, I added tests to check that the svgplvm and svgp elbo are unbiased when batching (see `test_models.py`). 

Also, `svgp.elbo` now deals with batching internally, instead of relying on the users to scale the likelihood term appropriately. This is done by making `m` an attribute of both `Svgp` and `SvgpLvm`.