### PR TITLE
Batching over samples

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -125,7 +125,7 @@ def load_model(params):
     #### construct model ####
     device = (mgplvm.utils.get_device()
               if params['device'] is None else params['device'])
-    mod = models.SvgpLvm(n, m, z, kernel, likelihood, lat_dist,
+    mod = models.SvgpLvm(n, m, n_samples, z, kernel, likelihood, lat_dist,
                          lprior).to(device)
 
     return mod

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -69,10 +69,10 @@ class GP(LpriorEuclid):
         self.svgp = Svgp(kernel,
                          n,
                          m,
+                         n_samples,
                          z,
                          lik,
                          whiten=True,
-                         n_samples=n_samples,
                          tied_samples=False)  #construct svgp
 
     @property

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -20,9 +20,9 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
                  kernel: Kernel,
                  n: int,
                  m: int,
+                 n_samples: int,
                  n_inducing: int,
                  likelihood: Likelihood,
-                 n_samples: int = 1,
                  q_mu: Optional[Tensor] = None,
                  q_sqrt: Optional[Tensor] = None,
                  whiten=True,
@@ -35,12 +35,12 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
             number of neurons
         m : int 
             number of conditions
+        n_samples : int 
+            number of samples
         n_inducing : int
             number of inducing points
         likelihood : Likelihood
             likliehood module used for computing variational expectation
-        n_samples : int 
-            number of samples
         q_mu : Optional Tensor
             optional Tensor for initialization
         q_sqrt : Optional Tensor
@@ -144,7 +144,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         n_inducing = self.n_inducing  # inducing points
 
         # prior KL(q(u) || p(u)) (1 x n) if tied_samples otherwise (n_samples x n)
-        prior_kl = self.prior_kl()
+        prior_kl = self.prior_kl(sample_idxs)
         # predictive mean and var at x
         f_mean, f_var = self.predict(x, full_cov=False)
         prior_kl = prior_kl.sum(-2)
@@ -281,9 +281,9 @@ class Svgp(SvgpBase):
                  kernel: Kernel,
                  n: int,
                  m: int,
+                 n_samples: int,
                  z: InducingPoints,
                  likelihood: Likelihood,
-                 n_samples=1,
                  whiten: Optional[bool] = True,
                  tied_samples: Optional[bool] = True):
         """
@@ -296,12 +296,12 @@ class Svgp(SvgpBase):
             number of neurons
         m : int
             number of conditions
+        n_samples : int
+            number of samples 
         z : InducingPoints
             inducing points for sparse GP
         likelihood : Likelihood
             likleihood p(y | f) 
-        n_samples : int
-            number of samples 
         whiten : Optional bool
             whiten q if true
         tied_samples : Optional bool
@@ -320,9 +320,9 @@ class Svgp(SvgpBase):
         super().__init__(kernel,
                          n,
                          m,
+                         n_samples,
                          n_inducing,
                          likelihood,
-                         n_samples=n_samples,
                          whiten=whiten,
                          tied_samples=tied_samples)
         self.z = z

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -92,9 +92,12 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
     def _expand_x(self, x):
         pass
 
-    def prior_kl(self):
+    def prior_kl(self, sample_idxs=None):
         q_mu, q_sqrt, z = self.prms
         assert (q_mu.shape[0] == q_sqrt.shape[0])
+        if not self.tied_samples and sample_idxs is not None:
+            q_mu = q_mu[sample_idxs]
+            q_sqrt = q_sqrt[sample_idxs]
         z = self._expand_z(z)
         e = torch.eye(self.n_inducing).to(q_mu.device)
         if not self.whiten:
@@ -109,7 +112,10 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         return kl_divergence(q, prior)
 
-    def elbo(self, y: Tensor, x: Tensor) -> Tuple[Tensor, Tensor]:
+    def elbo(self,
+             y: Tensor,
+             x: Tensor,
+             sample_idxs: Optional[List[int]] = None) -> Tuple[Tensor, Tensor]:
         """
         Parameters
         ----------
@@ -131,20 +137,25 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         assert (x.shape[-3] == y.shape[-3])
         assert (x.shape[-1] == y.shape[-1])
+        batch_size = x.shape[-1]
+        sample_size = x.shape[-3]
 
         kernel = self.kernel
         n_inducing = self.n_inducing  # inducing points
-        prior_kl = self.prior_kl(
-        )  # prior KL(q(u) || p(u)) (1 x n) if tied_samples otherwise (n_samples x n)
+
+        # prior KL(q(u) || p(u)) (1 x n) if tied_samples otherwise (n_samples x n)
+        prior_kl = self.prior_kl()
         # predictive mean and var at x
         f_mean, f_var = self.predict(x, full_cov=False)
         prior_kl = prior_kl.sum(-2)
+        if not self.tied_samples:
+            prior_kl = prior_kl * (self.n_samples / sample_size)
 
         #(n_mc, n_samles, n)
         lik = self.likelihood.variational_expectation(y, f_mean, f_var)
-        batch_size = x.shape[-1]
-        # scale is (m / batch_size) to compute an unbiased estimate of the full dataset
-        scale = 1 if batch_size == self.m else (self.m / batch_size)
+        # scale is (m / batch_size) * (self.n_samples / sample size)
+        # to compute an unbiased estimate of the likelihood of the full dataset
+        scale = (self.m / batch_size) * (self.n_samples / sample_size)
         lik = lik.sum(-2)
         lik = lik * scale
 
@@ -177,7 +188,8 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         return y_samps
 
-    def predict(self, x: Tensor, full_cov: bool) -> Tuple[Tensor, Tensor]:
+    def predict(self, x: Tensor, full_cov: bool,
+                sample_idxs=None) -> Tuple[Tensor, Tensor]:
         """
         Parameters
         ----------
@@ -204,6 +216,9 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         q_mu = q_mu[..., None]
 
         assert (q_mu.shape[0] == q_sqrt.shape[0])
+        if not self.tied_samples and sample_idxs is not None:
+            q_mu = q_mu[sample_idxs]
+            q_sqrt = q_sqrt[sample_idxs]
 
         # see ELBO for explanation of _expand
         z = self._expand_z(z)

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -146,7 +146,9 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         # prior KL(q(u) || p(u)) (1 x n) if tied_samples otherwise (n_samples x n)
         prior_kl = self.prior_kl(sample_idxs)
         # predictive mean and var at x
-        f_mean, f_var = self.predict(x, full_cov=False)
+        f_mean, f_var = self.predict(x,
+                                     full_cov=False,
+                                     sample_idxs=sample_idxs)
         prior_kl = prior_kl.sum(-2)
         if not self.tied_samples:
             prior_kl = prior_kl * (self.n_samples / sample_size)
@@ -216,7 +218,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
         q_mu = q_mu[..., None]
 
         assert (q_mu.shape[0] == q_sqrt.shape[0])
-        if not self.tied_samples and sample_idxs is not None:
+        if (not self.tied_samples) and sample_idxs is not None:
             q_mu = q_mu[sample_idxs]
             q_sqrt = q_sqrt[sample_idxs]
 

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -22,13 +22,13 @@ class SvgpLvm(nn.Module):
     def __init__(self,
                  n: int,
                  m: int,
+                 n_samples: int,
                  z: InducingPoints,
                  kernel: Kernel,
                  likelihood: Likelihood,
                  lat_dist: Rdist,
                  lprior=Lprior,
                  whiten: bool = True,
-                 n_samples: int = 1,
                  tied_samples=True):
         """
         __init__ method for Vanilla model
@@ -38,6 +38,8 @@ class SvgpLvm(nn.Module):
             number of neurons
         m : int
             number of conditions
+        n_samples: int
+            number of samples
         z : Inducing Points
             inducing points
         kernel : Kernel
@@ -53,6 +55,7 @@ class SvgpLvm(nn.Module):
         """
         super().__init__()
         self.n = n
+        self.n_samples = n_samples
         self.kernel = kernel
         self.z = z
         self.likelihood = likelihood
@@ -60,9 +63,9 @@ class SvgpLvm(nn.Module):
         self.svgp = svgp.Svgp(self.kernel,
                               n,
                               m,
+                              n_samples,
                               self.z,
                               likelihood,
-                              n_samples=n_samples,
                               whiten=whiten,
                               tied_samples=tied_samples)
         # latent distribution

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -114,8 +114,8 @@ class SvgpLvm(nn.Module):
 
         n_samples, n, m = data.shape
 
-        g, lq = self.lat_dist.sample(torch.Size([n_mc]), data, batch_idxs,
-                                     sample_idxs)
+        g, lq = self.lat_dist.sample(torch.Size([n_mc]), data, batch_idxs=batch_idxs,
+                                     sample_idxs=sample_idxs)
         # g is shape (n_samples, n_mc, m, d)
         # lq is shape (n_mc x n_samples x m)
 

--- a/mgplvm/rdist/common.py
+++ b/mgplvm/rdist/common.py
@@ -13,19 +13,19 @@ class Rdist(Module, metaclass=abc.ABCMeta):
         self.kmax = kmax
 
     @abc.abstractmethod
-    def lat_gmu(self, Y, batch_idxs) -> Tensor:
+    def lat_gmu(self, Y, batch_idxs, sample_idxs) -> Tensor:
         pass
 
     @abc.abstractmethod
-    def lat_gamma(self, Y, batch_idxs) -> Tensor:
+    def lat_gamma(self, Y, batch_idxs, sample_idxs) -> Tensor:
         pass
 
     @abc.abstractmethod
-    def lat_prms(self, Y, batch_idxs) -> Tuple[Tensor, Tensor]:
+    def lat_prms(self, Y, batch_idxs, sample_idxs) -> Tuple[Tensor, Tensor]:
         pass
 
     @abc.abstractmethod
-    def sample(self, size, Y, batch_idxs, kmax) -> Tuple[Tensor, Tensor]:
+    def sample(self, size, Y, batch_idxs, sample_idxs, kmax) -> Tuple[Tensor, Tensor]:
         pass
 
     @abc.abstractmethod

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -35,7 +35,7 @@ def test_cv_runs():
     lik = likelihoods.Gaussian(n)
     lprior = mgplvm.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
-    mod = models.SvgpLvm(n, m, z, kernel, lik, lat_dist, lprior,
+    mod = models.SvgpLvm(n, m, n_samples, z, kernel, lik, lat_dist, lprior,
                          whiten=True).to(device)
 
     ### run cv ###

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -91,6 +91,7 @@ def test_kernels_run():
         z = manif.inducing_points(n, n_z)
         mod = models.SvgpLvm(n,
                              m,
+                             n_samples,
                              z,
                              kernel,
                              lik,

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -48,6 +48,7 @@ def test_likelihood_runs():
         z = manif.inducing_points(n, n_z)
         mod = models.SvgpLvm(n,
                              m,
+                             n_samples,
                              z,
                              kernel,
                              lik,

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -44,6 +44,7 @@ def test_manifs_runs():
         z = manif.inducing_points(n, n_z)
         mod = mgplvm.models.SvgpLvm(n,
                                     m,
+                                    n_samples,
                                     z,
                                     kernel,
                                     lik,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,6 +39,7 @@ def test_svgplvm_LL():
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
                              m,
+                             n_samples,
                              z,
                              kernel,
                              lik,
@@ -90,6 +91,7 @@ def test_svgplvm_batching():
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
                              m,
+                             n_samples,
                              z,
                              kernel,
                              lik,
@@ -140,9 +142,9 @@ def test_svgp_batching():
     svgp = mgp.models.svgp.Svgp(kernel,
                                 n,
                                 m,
+                                n_samples,
                                 z,
                                 lik,
-                                n_samples=n_samples,
                                 whiten=True)
     mod = svgp.to(device)
     lat_dist = lat_dist.to(device)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -59,7 +59,7 @@ def test_GP_prior():
     # generate model
     likelihood = mgp.likelihoods.Gaussian(n, variance=np.square(sigma))
     z = manif.inducing_points(n, n_z)
-    mod = mgp.models.SvgpLvm(n, m, z, kernel, likelihood, lat_dist,
+    mod = mgp.models.SvgpLvm(n, m, n_samples, z, kernel, likelihood, lat_dist,
                              lprior).to(device)
 
     ### test that training runs ###
@@ -127,6 +127,7 @@ def test_ARP_runs():
         z = manif.inducing_points(n, n_z)
         mod = mgp.models.SvgpLvm(n,
                                  m,
+                                 n_samples,
                                  z,
                                  kernel,
                                  lik,

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -43,6 +43,7 @@ def test_trial_structure():
     z1 = manif1.inducing_points(n, n_z, z=zs)
     mod1 = models.SvgpLvm(n,
                           m,
+                          n_samples,
                           z1,
                           kernel1,
                           lik1,
@@ -67,6 +68,7 @@ def test_trial_structure():
     z2 = manif2.inducing_points(n2, n_z, z=zs)
     mod2 = models.SvgpLvm(n2,
                           m2,
+                          1,
                           z2,
                           kernel2,
                           lik2,


### PR DESCRIPTION
In this PR, I add the option to batch over samples in `svgp` and `svgplvm`. I'm also now forcing users to specify the number of samples when creating `Svgp` and SvgpLvm`. I've also added corresponding tests in `test_models.py` to check that batching over samples gives an unbiased estimate of the elbo. In the spirit of micro PRs, we can update the `svgp` optimisation function to batch over samples in a future PR.