### PR TITLE
Batch sampler for batching over samples and conditions

### DIFF
--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -119,8 +119,8 @@ def test_cv(mod, split, device, n_mc=32, Print=False):
                              batch_idxs=T2,
                              neuron_idxs=N2)
 
-    svgp_elbo = svgp_elbo.sum(-1).sum(-1)  #(n_mc)
-    LLs = svgp_elbo - kl.sum(-1)  # LL for each batch (n_mc, )
+    svgp_elbo = svgp_elbo.sum(-1)  #(n_mc)
+    LLs = svgp_elbo - kl  # LL for each batch (n_mc, )
     LL = (torch.logsumexp(LLs, 0) - np.log(n_mc)).detach().cpu().numpy()
     LL = LL / (len(T2) * len(N2) * n_samples)
 

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -113,7 +113,8 @@ def test_cv(mod, split, device, n_mc=32, Print=False):
 
     ### compute crossvalidated log likelihood ###
     #(n_mc, n_samples, n), (n_mc, n_samples)
-    svgp_elbo, kl = mod.elbo(torch.tensor(Y).to(device),
+    data = torch.tensor(Y, device=device)
+    svgp_elbo, kl = mod.elbo(data[:, :, T2],
                              n_mc,
                              batch_idxs=T2,
                              neuron_idxs=N2)

--- a/mgplvm/kernels.py
+++ b/mgplvm/kernels.py
@@ -405,8 +405,8 @@ class Linear(Kernel):
 
         if alpha is not None:
             alpha = torch.tensor(alpha)
-        elif Y is not None:  # <Y^2> = alpha^2 * d * <x^2> = alpha^2 * d
-            alpha = torch.tensor(np.sqrt(np.var(Y, axis=(0, 2)) / d))
+        elif Y is not None:  # <Y^2> = alpha^2 * d * <x^2> + <eps^2> = alpha^2 * d + sig_noise^2
+            alpha = torch.tensor(np.sqrt(np.var(Y, axis=(0, 2)) / d))*0.5 #assume half signal half noise
         else:
             alpha = torch.ones(n, )  #one per neuron
         self.alpha = nn.Parameter(data=alpha, requires_grad=learn_alpha)

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -55,6 +55,7 @@ class SvgpLvm(nn.Module):
         """
         super().__init__()
         self.n = n
+        self.m = m
         self.n_samples = n_samples
         self.kernel = kernel
         self.z = z
@@ -112,15 +113,17 @@ class SvgpLvm(nn.Module):
         ELBO of the model per batch is [ svgp_elbo - kl ]
         """
 
-        n_samples, n, m = data.shape
+        n_samples, n, m = self.n_samples, self.n, self.m
 
-        g, lq = self.lat_dist.sample(torch.Size([n_mc]), data, batch_idxs=batch_idxs,
+        g, lq = self.lat_dist.sample(torch.Size([n_mc]),
+                                     data,
+                                     batch_idxs=batch_idxs,
                                      sample_idxs=sample_idxs)
         # g is shape (n_samples, n_mc, m, d)
         # lq is shape (n_mc x n_samples x m)
 
-        data = data if sample_idxs is None else data[..., sample_idxs, :, :]
-        data = data if batch_idxs is None else data[..., batch_idxs]
+        #data = data if sample_idxs is None else data[..., sample_idxs, :, :]
+        #data = data if batch_idxs is None else data[..., batch_idxs]
 
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)
         # and so we need to permute [ g ] to have the right dimensions

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -1,0 +1,66 @@
+import torch
+from torch.utils.data import Dataset
+
+
+class NeuralDataLoader:
+    def __init__(self,
+                 data,
+                 batch_size=None,
+                 sample_size=None,
+                 batch_pool=None,
+                 sample_pool=None):
+        n_samples, _, m = data.shape
+        self.n_samples = n_samples
+        self.m = m
+        self.batch_pool = batch_pool
+        self.sample_pool = sample_pool
+        self.batch_pool_size = m if batch_pool is None else len(batch_pool)
+        self.sample_pool_size = n_samples if sample_pool is None else len(
+            sample_pool)
+        self.batch_size = self.batch_pool_size if batch_size is None else batch_size
+        self.sample_size = self.sample_pool_size if sample_size is None else sample_size
+        if sample_pool is not None:
+            data = data[sample_pool]
+        if batch_pool is not None:
+            data = data[:, :, batch_pool]
+        self.data = data
+        if self.batch_size > self.batch_pool_size:
+            raise Exception(
+                "batch size greater than number of conditions in pool")
+        if self.sample_size > self.sample_pool_size:
+            raise Exception(
+                "sample size greater than number of samples in pool")
+
+    def get_next(self):
+        i0 = self.i
+        i1 = i0 + self.sample_size
+        k0 = self.k
+        k1 = k0 + self.batch_size
+        if i1 > self.sample_pool_size:
+            i1 = self.sample_pool_size
+        if k1 > self.batch_pool_size:
+            k1 = self.batch_pool_size
+        batch = self.data[i0:i1][:, :, k0:k1]
+        self.k = k1
+        batch_idxs = list(range(k0, k1))
+        sample_idxs = list(range(i0, i1))
+        return sample_idxs, batch_idxs, batch
+
+    def __iter__(self):
+        self.i = 0
+        self.k = 0
+        return self
+
+    def __next__(self):
+        if self.i >= self.sample_pool_size:
+            raise StopIteration
+        else:
+            if self.k >= self.batch_pool_size:
+                self.k = 0
+                self.i += self.sample_size
+                if self.i >= self.sample_pool_size:
+                    raise StopIteration
+                else:
+                    return self.get_next()
+            else:
+                return self.get_next()

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -44,6 +44,10 @@ class NeuralDataLoader:
         self.k = k1
         batch_idxs = list(range(k0, k1))
         sample_idxs = list(range(i0, i1))
+        if self.batch_pool is not None:
+            batch_idxs = [self.batch_pool[i] for i in batch_idxs]
+        if self.sample_pool is not None:
+            sample_idxs = [self.sample_pool[i] for i in sample_idxs]
         return sample_idxs, batch_idxs, batch
 
     def __iter__(self):

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -64,38 +64,6 @@ def print_progress(model,
         print(msg + model.kernel.msg + model.lprior.msg, end="\r")
 
 
-def generate_batch_idxs(model, data_size, batch_pool=None, batch_size=None):
-    if (batch_size is None and batch_pool is None):
-        batch_idxs = None
-        return batch_idxs
-    elif batch_size is None:
-        batch_idxs = batch_pool
-        return batch_idxs
-    else:
-        if batch_pool is None:
-            idxs = np.arange(data_size)
-        else:
-            idxs = batch_pool
-        if model.lprior.name in ["Brownian", "ARP"]:
-            # if prior is Brownian or ARP, then batches have to be contiguous
-            i0 = np.random.randint(1, data_size - 1)
-            if i0 < batch_size / 2:
-                batch_idxs = idxs[:int(round(batch_size / 2 + i0))]
-            elif i0 > (data_size - batch_size / 2):
-                batch_idxs = idxs[int(round(i0 - batch_size / 2)):]
-            else:
-                batch_idxs = idxs[int(round(i0 - batch_size /
-                                            2)):int(round(i0 +
-                                                          batch_size / 2))]
-            #print(len(batch_idxs))
-            return batch_idxs
-        else:
-            if batch_size is None:
-                return idxs
-            else:
-                return np.random.choice(idxs, size=batch_size, replace=False)
-
-
 def fit(Y,
         model,
         device,

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -20,13 +20,13 @@ def sort_params(model, hook):
             model.likelihood.parameters(),
             model.lprior.parameters(),
             model.lat_dist.gmu_parameters(),
-            model.kernel.parameters(),
             [model.svgp.q_mu, model.svgp.q_sqrt],
         ]))
 
     params1 = list(
         itertools.chain.from_iterable(
-            [model.lat_dist.concentration_parameters()]))
+            [model.lat_dist.concentration_parameters(),
+            model.kernel.parameters()]))
 
     params = [{'params': params0}, {'params': params1}]
     return params

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -103,7 +103,6 @@ def fit(Y,
         n, m = Y.shape  # neuron x conditions
         n_samples = 1
     data = torch.tensor(Y, dtype=torch.get_default_dtype()).to(device)
-    data_size = m if batch_pool is None else len(batch_pool)  #total conditions
     n = n if neuron_idxs is None else len(neuron_idxs)
     #optionally mask some time points
     mask_Ts = mask_Ts if mask_Ts is not None else lambda x: x

--- a/mgplvm/rdist/relie.py
+++ b/mgplvm/rdist/relie.py
@@ -119,14 +119,12 @@ class _F(Module):
 
         if sample_idxs is not None:
             gmu = gmu[sample_idxs]
-            gamma= gamma[sample_idxs]
+            gamma = gamma[sample_idxs]
 
         if batch_idxs is None:
             return gmu, gamma
         else:
             return gmu[:, batch_idxs, :], gamma[:, batch_idxs, :]
-
-
 
     @property
     def prms(self):

--- a/tests/test_data_sampler.py
+++ b/tests/test_data_sampler.py
@@ -1,0 +1,53 @@
+import numpy as np
+import mgplvm as mgp
+
+
+def test_sampler():
+    n_samples = 10
+    m = 20
+    n = 10
+    sample_size = 3
+    batch_size = 7
+    Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
+    dataloader = mgp.optimisers.data.NeuralDataLoader(Y,
+                                                      sample_size=sample_size,
+                                                      batch_size=batch_size)
+
+    k = int(np.ceil(m / batch_size)) * int(np.ceil(n_samples / sample_size))
+    assert (k == len(list(dataloader)))
+    for sample_idxs, batch_idxs, batch in dataloader:
+        assert (batch.shape[1] == n)
+        assert (batch.shape[0] <= sample_size)
+        assert (batch.shape[2] <= batch_size)
+        assert np.alltrue(Y[sample_idxs][:, :, batch_idxs] == batch)
+
+
+def test_sampler_pool():
+    n_samples = 10
+    m = 20
+    n = 10
+    sample_size = 3
+    batch_size = 7
+    batch_pool = list(range(0, m // 2))
+    sample_pool = list(range(0, n_samples // 2))
+    Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
+    dataloader = mgp.optimisers.data.NeuralDataLoader(Y,
+                                                      batch_pool=batch_pool,
+                                                      sample_pool=sample_pool,
+                                                      sample_size=sample_size,
+                                                      batch_size=batch_size)
+
+    k = int(np.ceil(len(batch_pool) / batch_size)) * int(
+        np.ceil(len(sample_pool) / sample_size))
+    assert (k == len(list(dataloader)))
+    for sample_idxs, batch_idxs, batch in dataloader:
+        assert (batch.shape[1] == n)
+        assert (batch.shape[0] <= sample_size)
+        assert (batch.shape[2] <= batch_size)
+        assert np.alltrue(Y[sample_pool][:, :, batch_pool][sample_idxs]
+                          [:, :, batch_idxs] == batch)
+
+
+if __name__ == "__main__":
+    test_sampler()
+    test_sampler_pool()

--- a/tests/test_data_sampler.py
+++ b/tests/test_data_sampler.py
@@ -28,8 +28,8 @@ def test_sampler_pool():
     n = 10
     sample_size = 3
     batch_size = 7
-    batch_pool = list(range(0, m // 2))
-    sample_pool = list(range(0, n_samples // 2))
+    batch_pool = list(range(2, m // 2 + 2))
+    sample_pool = list(range(2, n_samples // 2 + 2))
     Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
     dataloader = mgp.optimisers.data.NeuralDataLoader(Y,
                                                       batch_pool=batch_pool,
@@ -44,8 +44,7 @@ def test_sampler_pool():
         assert (batch.shape[1] == n)
         assert (batch.shape[0] <= sample_size)
         assert (batch.shape[2] <= batch_size)
-        assert np.alltrue(Y[sample_pool][:, :, batch_pool][sample_idxs]
-                          [:, :, batch_idxs] == batch)
+        assert np.alltrue(Y[sample_idxs][:, :, batch_idxs] == batch)
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -114,7 +114,8 @@ def test_svgplvm_batching():
             sample_idxs = np.random.choice(n_samples,
                                            sample_size,
                                            replace=False)
-            svgp_elbo, svgp_kl = mod.forward(data,
+            batch = data[sample_idxs][:, :, batch_idxs]
+            svgp_elbo, svgp_kl = mod.forward(batch,
                                              n_mc=n_mc,
                                              batch_idxs=batch_idxs,
                                              sample_idxs=sample_idxs)


### PR DESCRIPTION
This is a first shot at batching over both samples and conditions in `optimisers.svgp.fit`. This is done by adding a new iterator class in `optimisers.data` called `NeuralDataloader`. Once you create a dataloader with

```python
dataloader = NeuralDataLoader(data, batch_pool=batch_pool, sample_pool=sample_pool, batch_size=batch_size, sample_size=sample_size)
```

You can then iterate over the batches with

```python
for sample_idxs, batch_idxs, batch in dataloader:
      do_somethin(sample_idxs, batch_idxs, batch)
```

where `batch` should be the same as `data[sample_idxs][:,:,batch_idxs]`.

One of the biggest changes in this PR is that we are no longer passing the full dataset to `svgplvm.elbo`. Instead, we are now passing in the `batch`.  

I've also added a two unit tests for `NeuralDataLoader` in `test_data_sampler.py`.

Should we get the user to construct the `dataloader` and pass it to `optimisers.svgp.fit` as opposed to what we are currently doing, which is directly building the `dataloader` inside the `fit` function? This will allow users to design their own data loaders. If the user is not batching it should be as simple as writing a wrapper for:
```python
data_loader = [(None, None, data)]
```
Thoughts, @davindicode @KrisJensen ? 

In a future PR, we should probably add a `shuffle` and `drop_last` option to `NeuralDataLoader` as in  `torch.utils.data.DataLoader`.


