### PR TITLE
DataLoader class

### DIFF
--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -55,6 +55,7 @@ def train_cv(mod,
     """
 
     _, n, m = Y.shape
+    data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
     nt_train = int(round(m / 2)) if nt_train is None else nt_train
     nn_train = int(round(n / 2)) if nn_train is None else nn_train
 
@@ -68,7 +69,7 @@ def train_cv(mod,
 
     #print(Y.shape, mod.lat_dist.prms[0].shape, mod.lat_dist.prms[1].shape)
 
-    train_model(mod, Y, device, train_ps1)
+    train_model(mod, data, train_ps1)
 
     ### construct a mask for some of the time points ####
     def mask_Ts(grad):
@@ -84,10 +85,10 @@ def train_cv(mod,
     ):  #only gradients for the latent distribution
         p.requires_grad = True
 
-    _ = train_model(mod, Y, device, train_ps2)
+    train_model(mod, data, train_ps2)
 
     if test:
-        _ = test_cv(mod, split, device, n_mc=train_ps['n_mc'], Print=True)
+        test_cv(mod, split, device, n_mc=train_ps['n_mc'], Print=True)
 
     return mod, split
 

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -29,11 +29,10 @@ def training_params(**kwargs):
     return params
 
 
-def train_model(mod, Y, device, params):
+def train_model(mod, data, params):
 
-    trained_mod = optimisers.svgp.fit(Y,
+    trained_mod = optimisers.svgp.fit(data,
                                       mod,
-                                      device,
                                       optimizer=params['optimizer'],
                                       max_steps=int(round(
                                           params['max_steps'])),

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -31,7 +31,7 @@ def training_params(**kwargs):
 
 def train_model(mod, data, params):
 
-    dataloader = optimisers.data.NeuralDataLoader(
+    dataloader = optimisers.data.BatchDataLoader(
         data, batch_size=params['batch_size'], batch_pool=params['batch_pool'])
 
     trained_mod = optimisers.svgp.fit(dataloader,

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -31,7 +31,10 @@ def training_params(**kwargs):
 
 def train_model(mod, data, params):
 
-    trained_mod = optimisers.svgp.fit(data,
+    dataloader = optimisers.data.NeuralDataLoader(
+        data, batch_size=params['batch_size'], batch_pool=params['batch_pool'])
+
+    trained_mod = optimisers.svgp.fit(dataloader,
                                       mod,
                                       optimizer=params['optimizer'],
                                       max_steps=int(round(
@@ -40,9 +43,7 @@ def train_model(mod, data, params):
                                       n_mc=params['n_mc'],
                                       lrate=params['lrate'],
                                       print_every=params['print_every'],
-                                      batch_size=params['batch_size'],
                                       stop=params['callback'],
-                                      batch_pool=params['batch_pool'],
                                       neuron_idxs=params['neuron_idxs'],
                                       mask_Ts=params['mask_Ts']),
 

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -1,4 +1,5 @@
 import torch
+import numpy as np
 from torch.utils.data import Dataset
 
 
@@ -8,15 +9,19 @@ class NeuralDataLoader:
                  batch_size=None,
                  sample_size=None,
                  batch_pool=None,
-                 sample_pool=None):
+                 sample_pool=None,
+                 shuffle_batch=False,
+                 shuffle_sample=False):
         n_samples, _, m = data.shape
+        self.shuffle_batch = shuffle_batch
+        self.shuffle_sample = shuffle_sample
         self.n_samples = n_samples
         self.m = m
-        self.batch_pool = batch_pool
-        self.sample_pool = sample_pool
-        self.batch_pool_size = m if batch_pool is None else len(batch_pool)
-        self.sample_pool_size = n_samples if sample_pool is None else len(
-            sample_pool)
+        self.batch_pool = list(range(m)) if batch_pool is None else batch_pool
+        self.sample_pool = list(
+            range(n_samples)) if sample_pool is None else sample_pool
+        self.batch_pool_size = len(self.batch_pool)
+        self.sample_pool_size = len(self.sample_pool)
         self.batch_size = self.batch_pool_size if batch_size is None else batch_size
         self.sample_size = self.sample_pool_size if sample_size is None else sample_size
         if sample_pool is not None:
@@ -43,16 +48,26 @@ class NeuralDataLoader:
         batch = self.data[i0:i1][:, :, k0:k1]
         self.k = k1
         batch_idxs = list(range(k0, k1))
+        batch_idxs = [self.batch_pool[i] for i in batch_idxs]
         sample_idxs = list(range(i0, i1))
-        if self.batch_pool is not None:
-            batch_idxs = [self.batch_pool[i] for i in batch_idxs]
-        if self.sample_pool is not None:
-            sample_idxs = [self.sample_pool[i] for i in sample_idxs]
+        sample_idxs = [self.sample_pool[i] for i in sample_idxs]
         return sample_idxs, batch_idxs, batch
 
     def __iter__(self):
         self.i = 0
         self.k = 0
+        if self.shuffle_sample:
+            sample_shuffle_idxs = list(range(self.sample_pool_size))
+            np.random.shuffle(sample_shuffle_idxs)
+            self.sample_pool = [
+                self.sample_pool[i] for i in sample_shuffle_idxs
+            ]
+            self.data = self.data[sample_shuffle_idxs]
+        if self.shuffle_batch:
+            batch_shuffle_idxs = list(range(self.batch_pool_size))
+            np.random.shuffle(batch_shuffle_idxs)
+            self.batch_pool = [self.batch_pool[i] for i in batch_shuffle_idxs]
+            self.data = self.data[:, :, batch_shuffle_idxs]
         return self
 
     def __next__(self):

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -23,7 +23,7 @@ class DataLoader:
             raise StopIteration
 
 
-class NeuralDataLoader(DataLoader):
+class BatchDataLoader(DataLoader):
     def __init__(self,
                  data,
                  batch_size=None,

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -3,7 +3,27 @@ import numpy as np
 from torch.utils.data import Dataset
 
 
-class NeuralDataLoader:
+class DataLoader:
+    def __init__(self, data):
+        n_samples, n, m = data.shape
+        self.n = n
+        self.n_samples = n_samples
+        self.m = m
+        self.data = data
+
+    def __iter__(self):
+        self.i = 0
+        return self
+
+    def __next__(self):
+        if self.i == 0:
+            self.i += 1
+            return (None, None, self.data)
+        else:
+            raise StopIteration
+
+
+class NeuralDataLoader(DataLoader):
     def __init__(self,
                  data,
                  batch_size=None,
@@ -12,12 +32,11 @@ class NeuralDataLoader:
                  sample_pool=None,
                  shuffle_batch=False,
                  shuffle_sample=False):
-        n_samples, n, m = data.shape
-        self.n = n
+        super(NeuralDataLoader, self).__init__(data)
+        m = self.m
+        n_samples = self.n_samples
         self.shuffle_batch = shuffle_batch
         self.shuffle_sample = shuffle_sample
-        self.n_samples = n_samples
-        self.m = m
         self.batch_pool = list(range(m)) if batch_pool is None else batch_pool
         self.sample_pool = list(
             range(n_samples)) if sample_pool is None else sample_pool
@@ -26,10 +45,9 @@ class NeuralDataLoader:
         self.batch_size = self.batch_pool_size if batch_size is None else batch_size
         self.sample_size = self.sample_pool_size if sample_size is None else sample_size
         if sample_pool is not None:
-            data = data[sample_pool]
+            self.data = self.data[sample_pool]
         if batch_pool is not None:
-            data = data[:, :, batch_pool]
-        self.data = data
+            self.data = self.data[:, :, batch_pool]
         if self.batch_size > self.batch_pool_size:
             raise Exception(
                 "batch size greater than number of conditions in pool")

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -12,7 +12,8 @@ class NeuralDataLoader:
                  sample_pool=None,
                  shuffle_batch=False,
                  shuffle_sample=False):
-        n_samples, _, m = data.shape
+        n_samples, n, m = data.shape
+        self.n = n
         self.shuffle_batch = shuffle_batch
         self.shuffle_sample = shuffle_sample
         self.n_samples = n_samples

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -32,7 +32,7 @@ class BatchDataLoader(DataLoader):
                  sample_pool=None,
                  shuffle_batch=False,
                  shuffle_sample=False):
-        super(NeuralDataLoader, self).__init__(data)
+        super(BatchDataLoader, self).__init__(data)
         m = self.m
         n_samples = self.n_samples
         self.shuffle_batch = shuffle_batch

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -64,9 +64,8 @@ def print_progress(model,
         print(msg + model.kernel.msg + model.lprior.msg, end="\r")
 
 
-def fit(Y,
+def fit(data,
         model,
-        device,
         optimizer=optim.Adam,
         n_mc=128,
         burnin=100,
@@ -83,10 +82,8 @@ def fit(Y,
     '''
     Parameters
     ----------
-    Y : np.array
+    data : Tensor
         data matrix of dimensions (n_samples x n x m)
-    device : torch.device
-        torch device
     max_steps : Optional[int], default=1000
         maximum number of training iterations
     batch_pool : Optional[int list]
@@ -97,12 +94,7 @@ def fit(Y,
     def fburn(x):
         return 1 - np.exp(-x / (3 * burnin))
 
-    if len(Y.shape) > 2:
-        n_samples, n, m = Y.shape  # samples, neurons, conditions
-    else:
-        n, m = Y.shape  # neuron x conditions
-        n_samples = 1
-    data = torch.tensor(Y, dtype=torch.get_default_dtype()).to(device)
+    n_samples, n, m = data.shape  # samples, neurons, conditions
     n = n if neuron_idxs is None else len(neuron_idxs)
     #optionally mask some time points
     mask_Ts = mask_Ts if mask_Ts is not None else lambda x: x

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -35,7 +35,14 @@ def test_cv_runs():
     lik = likelihoods.Gaussian(n)
     lprior = mgplvm.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
-    mod = models.SvgpLvm(n, m, n_samples, z, kernel, lik, lat_dist, lprior,
+    mod = models.SvgpLvm(n,
+                         m,
+                         n_samples,
+                         z,
+                         kernel,
+                         lik,
+                         lat_dist,
+                         lprior,
                          whiten=True).to(device)
 
     ### run cv ###
@@ -45,7 +52,7 @@ def test_cv_runs():
                                                max_steps=10,
                                                n_mc=32)
     mod, split = mgplvm.crossval.train_cv(mod, Y, device, train_ps, test=False)
-    _ = mgplvm.crossval.test_cv(mod, split, device, Print=True)
+    mgplvm.crossval.test_cv(mod, split, device, Print=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_data_sampler.py
+++ b/tests/test_data_sampler.py
@@ -11,7 +11,7 @@ def test_sampler():
     Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
     for shuffle_batch in [True, False]:
         for shuffle_sample in [True, False]:
-            dataloader = mgp.optimisers.data.NeuralDataLoader(
+            dataloader = mgp.optimisers.data.BatchDataLoader(
                 Y, sample_size=sample_size, batch_size=batch_size)
 
             k = int(np.ceil(m / batch_size)) * int(
@@ -39,7 +39,7 @@ def test_sampler_pool():
     Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
     for shuffle_batch in [True, False]:
         for shuffle_sample in [True, False]:
-            dataloader = mgp.optimisers.data.NeuralDataLoader(
+            dataloader = mgp.optimisers.data.BatchDataLoader(
                 Y,
                 batch_pool=batch_pool,
                 sample_pool=sample_pool,

--- a/tests/test_data_sampler.py
+++ b/tests/test_data_sampler.py
@@ -9,17 +9,23 @@ def test_sampler():
     sample_size = 3
     batch_size = 7
     Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
-    dataloader = mgp.optimisers.data.NeuralDataLoader(Y,
-                                                      sample_size=sample_size,
-                                                      batch_size=batch_size)
+    for shuffle_batch in [True, False]:
+        for shuffle_sample in [True, False]:
+            dataloader = mgp.optimisers.data.NeuralDataLoader(
+                Y, sample_size=sample_size, batch_size=batch_size)
 
-    k = int(np.ceil(m / batch_size)) * int(np.ceil(n_samples / sample_size))
-    assert (k == len(list(dataloader)))
-    for sample_idxs, batch_idxs, batch in dataloader:
-        assert (batch.shape[1] == n)
-        assert (batch.shape[0] <= sample_size)
-        assert (batch.shape[2] <= batch_size)
-        assert np.alltrue(Y[sample_idxs][:, :, batch_idxs] == batch)
+            k = int(np.ceil(m / batch_size)) * int(
+                np.ceil(n_samples / sample_size))
+            assert (k == len(list(dataloader)))
+            # loop through the dataloader 3 times
+            # to see that it works even with in-place shuffling
+            for _ in range(3):
+                for sample_idxs, batch_idxs, batch in dataloader:
+                    assert (batch.shape[1] == n)
+                    assert (batch.shape[0] <= sample_size)
+                    assert (batch.shape[2] <= batch_size)
+                    assert np.alltrue(
+                        Y[sample_idxs][:, :, batch_idxs] == batch)
 
 
 def test_sampler_pool():
@@ -31,20 +37,28 @@ def test_sampler_pool():
     batch_pool = list(range(2, m // 2 + 2))
     sample_pool = list(range(2, n_samples // 2 + 2))
     Y = np.arange(n_samples * m * n).reshape(n_samples, n, m)
-    dataloader = mgp.optimisers.data.NeuralDataLoader(Y,
-                                                      batch_pool=batch_pool,
-                                                      sample_pool=sample_pool,
-                                                      sample_size=sample_size,
-                                                      batch_size=batch_size)
-
-    k = int(np.ceil(len(batch_pool) / batch_size)) * int(
-        np.ceil(len(sample_pool) / sample_size))
-    assert (k == len(list(dataloader)))
-    for sample_idxs, batch_idxs, batch in dataloader:
-        assert (batch.shape[1] == n)
-        assert (batch.shape[0] <= sample_size)
-        assert (batch.shape[2] <= batch_size)
-        assert np.alltrue(Y[sample_idxs][:, :, batch_idxs] == batch)
+    for shuffle_batch in [True, False]:
+        for shuffle_sample in [True, False]:
+            dataloader = mgp.optimisers.data.NeuralDataLoader(
+                Y,
+                batch_pool=batch_pool,
+                sample_pool=sample_pool,
+                sample_size=sample_size,
+                batch_size=batch_size,
+                shuffle_batch=shuffle_batch,
+                shuffle_sample=shuffle_sample)
+            k = int(np.ceil(len(batch_pool) / batch_size)) * int(
+                np.ceil(len(sample_pool) / sample_size))
+            assert (k == len(list(dataloader)))
+            # loop through the dataloader 3 times
+            # to see that it works even with in-place shuffling
+            for _ in range(2):
+                for sample_idxs, batch_idxs, batch in dataloader:
+                    assert (batch.shape[1] == n)
+                    assert (batch.shape[0] <= sample_size)
+                    assert (batch.shape[2] <= batch_size)
+                    assert np.alltrue(
+                        Y[sample_idxs][:, :, batch_idxs] == batch)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -72,7 +72,7 @@ def test_kernels_run():
                       n_samples=n_samples)
     sig0 = 1.5
     Y = gen.gen_data(ell=25, sig=1)
-
+    data = torch.tensor(Y, dtype=torch.get_default_dtype(), device=device)
     kernels = [
         QuadExp(n, Euclid.distance),
         Linear(n, Euclid.linear_distance, d),
@@ -100,9 +100,8 @@ def test_kernels_run():
                              whiten=True).to(device)
 
         ### test that training runs ###
-        trained_mod = optimisers.svgp.fit(Y,
+        trained_mod = optimisers.svgp.fit(data,
                                           mod,
-                                          device,
                                           optimizer=optim.Adam,
                                           max_steps=5,
                                           burnin=100,

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -29,6 +29,7 @@ def test_likelihood_runs():
                       n_samples=n_samples)
     Y = gen.gen_data()
     Y = np.round(Y - np.amin(Y))
+    data = torch.tensor(Y, dtype=torch.get_default_dtype(), device=device)
     print(Y.shape)
 
     for lik in [
@@ -57,9 +58,8 @@ def test_likelihood_runs():
                              whiten=True).to(device)
 
         # train model
-        optimisers.svgp.fit(Y,
+        optimisers.svgp.fit(data,
                             mod,
-                            device,
                             optimizer=optim.Adam,
                             max_steps=5,
                             burnin=5 / 2E-2,
@@ -68,9 +68,9 @@ def test_likelihood_runs():
                             print_every=1000)
 
         ### test burda log likelihood ###
-        LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
+        LL = mod.calc_LL(data, 128)
         print("once")
-        svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
+        svgp_elbo, kl = mod.forward(data, 128)
         elbo = (svgp_elbo - kl) / np.prod(Y.shape)
 
         assert elbo <= LL

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -28,6 +28,7 @@ def test_so3_dimensions():
 def test_manifs_runs():
     m, d, n, n_z, n_samples = 10, 3, 5, 5, 2
     Y = np.random.normal(0, 1, (n_samples, n, m))
+    data = torch.tensor(Y, dtype=torch.get_default_dtype(), device=device)
     for i, manif_type in enumerate(
         [manifolds.Torus, manifolds.So3, manifolds.S3]):
         manif = manif_type(m, d)
@@ -53,9 +54,8 @@ def test_manifs_runs():
                                     whiten=True).to(device)
 
         # train model
-        trained_model = optimisers.svgp.fit(Y,
+        trained_model = optimisers.svgp.fit(data,
                                             mod,
-                                            device,
                                             max_steps=5,
                                             n_mc=64,
                                             optimizer=optim.Adam,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,10 +47,10 @@ def test_svgplvm_LL():
                              lprior,
                              whiten=True).to(device)
 
+    data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
     # train model
-    mgp.optimisers.svgp.fit(Y,
+    mgp.optimisers.svgp.fit(data,
                             mod,
-                            device,
                             optimizer=optim.Adam,
                             max_steps=5,
                             burnin=5 / 2E-2,
@@ -59,8 +59,8 @@ def test_svgplvm_LL():
                             print_every=1000)
 
     ### test burda log likelihood ###
-    LL = mod.calc_LL(torch.tensor(Y).to(device), 128)
-    svgp_elbo, kl = mod.forward(torch.tensor(Y).to(device), 128)
+    LL = mod.calc_LL(data, 128)
+    svgp_elbo, kl = mod.forward(data, 128)
     elbo = (svgp_elbo - kl).data.cpu().numpy() / np.prod(Y.shape)
 
     assert elbo < LL

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -26,6 +26,7 @@ def test_GP_prior():
                           n_samples=n_samples)
     sig0 = 1.5
     Y = gen.gen_data(ell=25, sig=1)
+    data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
     # specify manifold, kernel and rdist
     manif = mgp.manifolds.Euclid(m, d)
     alpha = np.mean(np.std(Y, axis=-1), axis=0)
@@ -65,9 +66,8 @@ def test_GP_prior():
     ### test that training runs ###
     n_mc = 64
 
-    mgp.optimisers.svgp.fit(Y,
+    mgp.optimisers.svgp.fit(data,
                             mod,
-                            device,
                             optimizer=optim.Adam,
                             n_mc=n_mc,
                             max_steps=5,
@@ -80,7 +80,6 @@ def test_GP_prior():
                                 mod.lprior.svgp.q_mu[1].detach().data)))
 
     ### test that two ways of computing the prior agree ###
-    data = torch.tensor(Y).to(device)
     g, lq = mod.lat_dist.sample(torch.Size([n_mc]), data, None)
     g = g.transpose(-1, -2)
 
@@ -109,6 +108,7 @@ def test_ARP_runs():
     m, d, n, n_z, p = 10, 3, 5, 5, 1
     n_samples = 2
     Y = np.random.normal(0, 1, (n_samples, n, m))
+    data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
     for i, manif_type in enumerate(
         [mgp.manifolds.Euclid, mgp.manifolds.Torus, mgp.manifolds.So3]):
         manif = manif_type(m, d)
@@ -136,9 +136,8 @@ def test_ARP_runs():
                                  whiten=True).to(device)
 
         # train model
-        mgp.optimisers.svgp.fit(Y,
+        mgp.optimisers.svgp.fit(data,
                                 mod,
-                                device,
                                 max_steps=5,
                                 n_mc=64,
                                 optimizer=optim.Adam,


### PR DESCRIPTION
This PR should not be merged before #24 . I've added a `shuffle_batch` and `shuffle_sample` option to `BatchDataLoader` (it used to be called `NeuralDataLoader` in #24). 

In addition, we can now directly pass a `optimisers.data.DataLoader` to `optimisers.svgp.fit` instead of building it inside the `fit` function.

The workflow becomes:
```python
dataloader = BatchDataLoader(data, batch_size=batch_size,...)
fit(dataloader, ...)
```

We can still directly pass data as a `torch.Tensor` to `fit` (see `optimiser.svpg.fit`). 