### PR TITLE
Linear ARD & remove linear distances

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -41,7 +41,11 @@ def model_params(n, m, d, n_z, n_samples, **kwargs):
     }
 
     for key, value in kwargs.items():
-        params[key] = value
+        if key in params.keys():
+            params[key] = value
+        else:
+            print('key not found; adding', key)
+            params[key] = value
 
     return params
 
@@ -112,9 +116,7 @@ def load_model(params):
 
     #### specify likelihood ####
     if params['likelihood'] == 'Gaussian':
-        var = None if params['lik_gauss_std'] is None else np.square(
-            params['lik_gauss_std'])
-        likelihood: Likelihood = likelihoods.Gaussian(n, variance=var)
+        likelihood: Likelihood = likelihoods.Gaussian(n, sigma = params['lik_gauss_std'])
     elif params['likelihood'] == 'Poisson':
         likelihood = likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':

--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -116,7 +116,8 @@ def load_model(params):
 
     #### specify likelihood ####
     if params['likelihood'] == 'Gaussian':
-        likelihood: Likelihood = likelihoods.Gaussian(n, sigma = params['lik_gauss_std'])
+        likelihood: Likelihood = likelihoods.Gaussian(
+            n, sigma=params['lik_gauss_std'])
     elif params['likelihood'] == 'Poisson':
         likelihood = likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':

--- a/mgplvm/kernels/linear.py
+++ b/mgplvm/kernels/linear.py
@@ -72,7 +72,7 @@ class Linear(Kernel):
         trK : Tensor
             trace of kernel K(x,x) with dims (... n)
         """
-        
+
         # compute x dot y with latent reweighting
         dot = self.reweight(x).transpose(-1, -2).matmul(self.reweight(y))
         # multiply by scale factor
@@ -102,5 +102,6 @@ class Linear(Kernel):
 
     @property
     def msg(self):
-        return ('scale {:.3f} | input_scale {:.3f} |').format(self.scale.mean().item(),
-                                                      self.input_scale.mean().item())
+        return ('scale {:.3f} | input_scale {:.3f} |').format(
+            self.scale.mean().item(),
+            self.input_scale.mean().item())

--- a/mgplvm/kernels/linear.py
+++ b/mgplvm/kernels/linear.py
@@ -65,10 +65,10 @@ class Linear(Kernel):
             trace of kernel K(x,x) with dims (... n)
         """
         dot = self.dot(self.prmtize(x), self.prmtize(y))
-        kxy = self.scale_sqr[:, None, None] * distance
+        kxy = self.scale_sqr[:, None, None] * dot
         return kxy
     
-    def prmtize(self, x: Tensor) --> Tensor:
+    def prmtize(self, x: Tensor) -> Tensor:
         """re-weight the latent dimensions"""
         x = self.ell[:, None] * x
         return x
@@ -87,7 +87,7 @@ class Linear(Kernel):
     
     @property
     def ell(self) -> Tensor:
-        return softplus(self._ell())
+        return softplus(self._ell)
 
     @property
     def msg(self):

--- a/mgplvm/kernels/linear.py
+++ b/mgplvm/kernels/linear.py
@@ -32,7 +32,7 @@ class Linear(Kernel):
 
         if scale is not None:
             _scale = torch.tensor(scale)
-        elif Y is not None:  # <Y^2> = scale * d * <x^2> + <eps^2> = scale * d + sig_noise^2
+        elif (Y is not None) and learn_scale:  # <Y^2> = scale * d * <x^2> + <eps^2> = scale * d + sig_noise^2
             _scale = torch.tensor(np.sqrt(np.var(
                 Y, axis=(0, 2)) / d)) * 0.5  #assume half signal half noise
         else:
@@ -91,7 +91,7 @@ class Linear(Kernel):
 
     @property
     def msg(self):
-        return ('scale {:.3f} |').format(self.scale.mean().item())
+        return ('scale {:.3f} | ell {:.3f} |').format(self.scale.mean().item(), self.ell.mean().item())
     
     @staticmethod
     def dot(x: Tensor, y: Tensor) -> Tensor:

--- a/mgplvm/kernels/linear.py
+++ b/mgplvm/kernels/linear.py
@@ -9,7 +9,13 @@ from ..utils import softplus, inv_softplus
 class Linear(Kernel):
     name = "Linear"
 
-    def __init__(self, n: int, d: int, scale=None, learn_scale=False, Y=None, ard = False):
+    def __init__(self,
+                 n: int,
+                 d: int,
+                 scale=None,
+                 learn_scale=False,
+                 Y=None,
+                 ard=False):
         '''
         n is number of neurons/readouts
         d is the dimensionality of the group parameterization
@@ -32,19 +38,21 @@ class Linear(Kernel):
 
         if scale is not None:
             _scale = torch.tensor(scale)
-        elif (Y is not None) and learn_scale:  # <Y^2> = scale * d * <x^2> + <eps^2> = scale * d + sig_noise^2
+        elif (
+                Y is not None
+        ) and learn_scale:  # <Y^2> = scale * d * <x^2> + <eps^2> = scale * d + sig_noise^2
             _scale = torch.tensor(np.sqrt(np.var(
                 Y, axis=(0, 2)) / d)) * 0.5  #assume half signal half noise
         else:
             _scale = torch.ones(n,)  #one per neuron
         self._scale = nn.Parameter(data=_scale, requires_grad=learn_scale)
-        
+
         _ell = inv_softplus(torch.ones(d))
         self._ell = nn.Parameter(data=_ell, requires_grad=ard)
-        
 
     def diagK(self, x: Tensor) -> Tensor:
-        diag = (self.scale_sqr[:, None, None] * (self.prmtize(x)**2)).sum(dim=-2)
+        diag = (self.scale_sqr[:, None, None] *
+                (self.prmtize(x)**2)).sum(dim=-2)
         return diag
 
     def trK(self, x: Tensor) -> Tensor:
@@ -67,14 +75,14 @@ class Linear(Kernel):
         dot = self.dot(self.prmtize(x), self.prmtize(y))
         kxy = self.scale_sqr[:, None, None] * dot
         return kxy
-    
+
     def prmtize(self, x: Tensor) -> Tensor:
         """re-weight the latent dimensions"""
         x = self.ell[:, None] * x
         return x
 
     @property
-    def prms(self) -> Tensor:
+    def prms(self) -> Tuple[Tensor, Tensor]:
         return self.scale, self.ell
 
     @property
@@ -84,15 +92,16 @@ class Linear(Kernel):
     @property
     def scale(self) -> Tensor:
         return self._scale.abs()
-    
+
     @property
     def ell(self) -> Tensor:
         return softplus(self._ell)
 
     @property
     def msg(self):
-        return ('scale {:.3f} | ell {:.3f} |').format(self.scale.mean().item(), self.ell.mean().item())
-    
+        return ('scale {:.3f} | ell {:.3f} |').format(self.scale.mean().item(),
+                                                      self.ell.mean().item())
+
     @staticmethod
     def dot(x: Tensor, y: Tensor) -> Tensor:
         dist = x.transpose(-1, -2).matmul(y)

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -55,7 +55,8 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
         else:
             _scale = torch.ones(n,)
 
-        self._scale = nn.Parameter(data=inv_softplus(_scale), requires_grad=learn_scale)
+        self._scale = nn.Parameter(data=inv_softplus(_scale),
+                                   requires_grad=learn_scale)
 
         self.ard = (d is not None)
         if ell is None:
@@ -65,7 +66,7 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
                 assert (d is not None)
                 _ell = inv_softplus(torch.ones(n, d))
             else:
-                _ell = inv_softplus(torch.ones(1,d))
+                _ell = inv_softplus(torch.ones(1, d))
         else:
             if d is not None:
                 assert ell.shape[-1] == d
@@ -198,10 +199,10 @@ class QuadExp(Stationary):
         """
         scale_sqr, ell = self.prms
         if self.ard:
-            ell = ell[:, :, None] #(n x d x 1)
+            ell = ell[:, :, None]  #(n x d x 1)
         else:
-            ell = ell[:, None, None] #(n x 1 x 1)
-        distance = self.distance(x, y, ell = ell)  # dims (... n x mx x my)
+            ell = ell[:, None, None]  #(n x 1 x 1)
+        distance = self.distance(x, y, ell=ell)  # dims (... n x mx x my)
         kxy = scale_sqr[:, None, None] * torch.exp(-0.5 * distance)
         return kxy
 
@@ -239,7 +240,7 @@ class Exp(QuadExp):
             ell = ell[:, :, None]
         else:
             ell = ell[:, None, None]
-        distance = self.distance(x, y, ell = ell)  # dims (... n x mx x my)
+        distance = self.distance(x, y, ell=ell)  # dims (... n x mx x my)
 
         # NOTE: distance means squared distance ||x-y||^2 ?
         stable_distance = torch.sqrt(distance + 1e-20)  # numerically stabilized
@@ -300,7 +301,7 @@ class Matern(Stationary):
             ell = ell[:, :, None]
         else:
             ell = ell[:, None, None]
-        distance = (self.distance(x, y, ell = ell) + 1E-20).sqrt()
+        distance = (self.distance(x, y, ell=ell) + 1E-20).sqrt()
 
         # NOTE: distance means squared distance ||x-y||^2 ?
         z1 = torch.exp(-math.sqrt(self.nu * 2) * distance)

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -18,7 +18,8 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
                  scale=None,
                  learn_scale=True,
                  Y: np.ndarray = None,
-                 eps: float = 1e-6):
+                 eps: float = 1e-6,
+                 ell_byneuron: bool = True):
         """
         Parameters
         ----------
@@ -54,15 +55,17 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
         else:
             _scale = torch.ones(n,)
 
-        self._scale = nn.Parameter(data=_scale, requires_grad=learn_scale)
+        self._scale = nn.Parameter(data=inv_softplus(_scale), requires_grad=learn_scale)
 
-        self.ard = d is not None
+        self.ard = (d is not None)
         if ell is None:
             if d is None:
                 _ell = inv_softplus(torch.ones(n,))
-            else:
+            elif ell_byneuron:
                 assert (d is not None)
                 _ell = inv_softplus(torch.ones(n, d))
+            else:
+                _ell = inv_softplus(torch.ones(1,d))
         else:
             if d is not None:
                 assert ell.shape[-1] == d
@@ -121,11 +124,11 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
 
     @property
     def scale_sqr(self) -> Tensor:
-        return self._scale.square()
+        return self.scale.square()
 
     @property
     def scale(self) -> Tensor:
-        return self._scale.abs()
+        return softplus(self._scale)
 
     @property
     def ell(self) -> Tensor:
@@ -147,7 +150,8 @@ class QuadExp(Stationary):
                  scale=None,
                  learn_scale=True,
                  Y: np.ndarray = None,
-                 eps: float = 1e-6):
+                 eps: float = 1e-6,
+                 ell_byneuron: bool = True):
         """
         Quadratic exponential kernel
 
@@ -175,7 +179,7 @@ class QuadExp(Stationary):
         """
 
         super(QuadExp, self).__init__(n, distance, d, ell, scale, learn_scale,
-                                      Y)
+                                      Y, eps, ell_byneuron)
 
     def K(self, x: Tensor, y: Tensor) -> Tensor:
         """
@@ -194,10 +198,10 @@ class QuadExp(Stationary):
         """
         scale_sqr, ell = self.prms
         if self.ard:
-            ell = ell[:, None, :]
+            ell = ell[:, :, None] #(n x d x 1)
         else:
-            ell = ell[:, None, None]
-        distance = self.distance(x / ell, y / ell)  # dims (... n x mx x my)
+            ell = ell[:, None, None] #(n x 1 x 1)
+        distance = self.distance(x, y, ell = ell)  # dims (... n x mx x my)
         kxy = scale_sqr[:, None, None] * torch.exp(-0.5 * distance)
         return kxy
 
@@ -232,11 +236,10 @@ class Exp(QuadExp):
         """
         scale_sqr, ell = self.prms
         if self.ard:
-            expand_ell = ell[:, None, :]
+            ell = ell[:, :, None]
         else:
-            expand_ell = ell[:, None, None]
-        distance = self.distance(x / expand_ell,
-                                 y / expand_ell)  # dims (... n x mx x my)
+            ell = ell[:, None, None]
+        distance = self.distance(x, y, ell = ell)  # dims (... n x mx x my)
 
         # NOTE: distance means squared distance ||x-y||^2 ?
         stable_distance = torch.sqrt(distance + 1e-20)  # numerically stabilized
@@ -294,12 +297,10 @@ class Matern(Stationary):
 
         scale_sqr, ell = self.prms
         if self.ard:
-            expand_ell = ell[:, None, :]
+            ell = ell[:, :, None]
         else:
-            expand_ell = ell[:, None, None]
-        x_ = x / expand_ell
-        y_ = y / expand_ell
-        distance = (self.distance(x_, y_) + 1E-20).sqrt()
+            ell = ell[:, None, None]
+        distance = (self.distance(x, y, ell = ell) + 1E-20).sqrt()
 
         # NOTE: distance means squared distance ||x-y||^2 ?
         z1 = torch.exp(-math.sqrt(self.nu * 2) * distance)

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -56,12 +56,12 @@ class Gaussian(Likelihood):
         self._sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
 
     @property
-    def prms(self):
+    def prms(self) -> Tensor:
         variance = torch.square(self._sigma)
         return variance
 
     @property
-    def sigma(self):
+    def sigma(self) -> Tensor:
         return (1e-20 + self.prms).sqrt()
 
     def log_prob(self, y):

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -48,11 +48,12 @@ class Gaussian(Likelihood):
 
     def __init__(self,
                  n: int,
-                 sigma: Optional[Tensor] = None,
+                 sigma: Optional[np.ndarray] = None,
                  n_gh_locs=n_gh_locs,
                  learn_sigma=True):
         super().__init__(n, n_gh_locs)
-        sigma = 1 * torch.ones(n,) if sigma is None else torch.tensor(sigma, dtype=torch.get_default_dtype())
+        sigma = 1 * torch.ones(n,) if sigma is None else torch.tensor(
+            sigma, dtype=torch.get_default_dtype())
         self.sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
 
     @property

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -48,17 +48,12 @@ class Gaussian(Likelihood):
 
     def __init__(self,
                  n: int,
-                 variance: Optional[Tensor] = None,
+                 sigma: Optional[Tensor] = None,
                  n_gh_locs=n_gh_locs,
                  learn_sigma=True):
         super().__init__(n, n_gh_locs)
-        sigma = 1 * torch.ones(n,) if variance is None else torch.sqrt(
-            torch.tensor(variance, dtype=torch.get_default_dtype()))
-
-        if learn_sigma:
-            self.sigma = nn.Parameter(data=sigma, requires_grad=True)
-        else:
-            self.sigma = nn.Parameter(data=sigma, requires_grad=False)
+        sigma = 1 * torch.ones(n,) if sigma is None else torch.tensor(sigma, dtype=torch.get_default_dtype())
+        self.sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
 
     @property
     def prms(self):

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -59,10 +59,10 @@ class Gaussian(Likelihood):
     def prms(self):
         variance = torch.square(self.sigma)
         return variance
-    
+
     @property
     def sigma(self):
-          return (1e-20 + self.prms).sqrt()
+        return (1e-20 + self.prms).sqrt()
 
     def log_prob(self, y):
         raise Exception("Gaussian likelihood not implemented")

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -53,11 +53,11 @@ class Gaussian(Likelihood):
                  learn_sigma=True):
         super().__init__(n, n_gh_locs)
         sigma = 1 * torch.ones(n,) if sigma is None else sigma
-        self.sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
+        self._sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
 
     @property
     def prms(self):
-        variance = torch.square(self.sigma)
+        variance = torch.square(self._sigma)
         return variance
 
     @property

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -48,12 +48,11 @@ class Gaussian(Likelihood):
 
     def __init__(self,
                  n: int,
-                 sigma: Optional[np.ndarray] = None,
+                 sigma: Optional[Tensor] = None,
                  n_gh_locs=n_gh_locs,
                  learn_sigma=True):
         super().__init__(n, n_gh_locs)
-        sigma = 1 * torch.ones(n,) if sigma is None else torch.tensor(
-            sigma, dtype=torch.get_default_dtype())
+        sigma = 1 * torch.ones(n,) if sigma is None else sigma
         self.sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
 
     @property

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -59,6 +59,10 @@ class Gaussian(Likelihood):
     def prms(self):
         variance = torch.square(self.sigma)
         return variance
+    
+    @property
+    def sigma(self):
+          return (1e-20 + self.prms).sqrt()
 
     def log_prob(self, y):
         raise Exception("Gaussian likelihood not implemented")

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -104,7 +104,7 @@ class GP(LpriorEuclid):
 
         # as the inducing points are shared across the full batch
         return elbo.sum(-1)  #sum over dimensions
-    
+
     @property
     def msg(self):
         ell = self.svgp.kernel.prms[1].mean()

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -66,7 +66,7 @@ class GP(LpriorEuclid):
         z = InducingPoints(n, d, n_z, z=zinit.repeat(n, d, 1))
         self.ts = ts
         #consider fixing this to a small value as in GPFA
-        lik = Gaussian(n, sigma=0.2, learn_sigma=False)
+        lik = Gaussian(n, sigma=np.ones(n) * 0.2, learn_sigma=False)
         self.svgp = Svgp(kernel,
                          n,
                          m,
@@ -108,7 +108,7 @@ class GP(LpriorEuclid):
     @property
     def msg(self):
         ell = self.svgp.kernel.prms[1].mean()
-        noise = self.svgp.likelihood.prms.sqrt()
+        noise = self.svgp.likelihood.prms.sqrt().mean()
 
         return (' prior ell {:.3f} | prior noise {:.3f} |').format(
             ell.item(), noise.item())

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -108,7 +108,7 @@ class GP(LpriorEuclid):
     @property
     def msg(self):
         ell = self.svgp.kernel.prms[1].mean()
-        noise = self.svgp.likelihood.sigma.mean()
+        noise = torch.mean(self.svgp.likelihood.sigma)
 
         return (' prior ell {:.3f} | prior noise {:.3f} |').format(
             ell.item(), noise.item())

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -104,11 +104,11 @@ class GP(LpriorEuclid):
 
         # as the inducing points are shared across the full batch
         return elbo.sum(-1)  #sum over dimensions
-
+    
     @property
     def msg(self):
         ell = self.svgp.kernel.prms[1].mean()
-        noise = self.svgp.likelihood.prms.sqrt().mean()
+        noise = self.svgp.likelihood.sigma.mean()
 
         return (' prior ell {:.3f} | prior noise {:.3f} |').format(
             ell.item(), noise.item())

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -66,13 +66,13 @@ class GP(LpriorEuclid):
         z = InducingPoints(n, d, n_z, z=zinit.repeat(n, d, 1))
         self.ts = ts
         #consider fixing this to a small value as in GPFA
-        lik = Gaussian(n, sigma=torch.ones(n) * 0.2, learn_sigma=False)
+        self.lik = Gaussian(n, sigma=torch.ones(n) * 0.2, learn_sigma=False)
         self.svgp = Svgp(kernel,
                          n,
                          m,
                          n_samples,
                          z,
-                         lik,
+                         self.lik,
                          whiten=True,
                          tied_samples=False)  #construct svgp
 
@@ -108,7 +108,7 @@ class GP(LpriorEuclid):
     @property
     def msg(self):
         ell = self.svgp.kernel.prms[1].mean()
-        noise = torch.mean(self.svgp.likelihood.sigma)
+        noise = self.lik.sigma.mean()
 
         return (' prior ell {:.3f} | prior noise {:.3f} |').format(
             ell.item(), noise.item())

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -66,7 +66,7 @@ class GP(LpriorEuclid):
         z = InducingPoints(n, d, n_z, z=zinit.repeat(n, d, 1))
         self.ts = ts
         #consider fixing this to a small value as in GPFA
-        lik = Gaussian(n, variance=np.square(0.2), learn_sigma=False)
+        lik = Gaussian(n, sigma=0.2, learn_sigma=False)
         self.svgp = Svgp(kernel,
                          n,
                          m,

--- a/mgplvm/lpriors/euclidean.py
+++ b/mgplvm/lpriors/euclidean.py
@@ -66,7 +66,7 @@ class GP(LpriorEuclid):
         z = InducingPoints(n, d, n_z, z=zinit.repeat(n, d, 1))
         self.ts = ts
         #consider fixing this to a small value as in GPFA
-        lik = Gaussian(n, sigma=np.ones(n) * 0.2, learn_sigma=False)
+        lik = Gaussian(n, sigma=torch.ones(n) * 0.2, learn_sigma=False)
         self.svgp = Svgp(kernel,
                          n,
                          m,

--- a/mgplvm/manifolds/base.py
+++ b/mgplvm/manifolds/base.py
@@ -58,11 +58,6 @@ class Manifold(metaclass=abc.ABCMeta):
     def distance(x: Tensor, y: Tensor) -> Tensor:
         pass
 
-    @staticmethod
-    @abc.abstractmethod
-    def linear_distance(x: Tensor, y: Tensor) -> Tensor:
-        pass
-
     @abc.abstractmethod
     def inducing_points(self, n: int, n_z: int, z=Optional[Tensor]):
         pass

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -83,9 +83,13 @@ class Euclid(Manifold):
         return x + y
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Tensor = torch.ones(1,1,1)) -> Tensor:
         # Based on implementation here: https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/kernels/kernel.py
 
+        #scale lengths by ell
+        x = x / ell
+        y = y / ell
+        
         # Compute squared distance matrix using quadratic expansion
         x_norm = x.pow(2).sum(dim=-2, keepdim=True)
         x_pad = torch.ones_like(x_norm)

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -83,13 +83,14 @@ class Euclid(Manifold):
         return x + y
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: Tensor = torch.ones(1,1,1)) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Tensor = torch.ones(1, 1,
+                                                                1)) -> Tensor:
         # Based on implementation here: https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/kernels/kernel.py
 
         #scale lengths by ell
         x = x / ell
         y = y / ell
-        
+
         # Compute squared distance matrix using quadratic expansion
         x_norm = x.pow(2).sum(dim=-2, keepdim=True)
         x_pad = torch.ones_like(x_norm)

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -83,14 +83,13 @@ class Euclid(Manifold):
         return x + y
 
     @staticmethod
-    def distance(
-        x: Tensor, y: Tensor, ell: Optional[Tensor] = torch.ones(1, 1,
-                                                                 1)) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Optional[Tensor] = None) -> Tensor:
         # Based on implementation here: https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/kernels/kernel.py
 
         #scale lengths by ell
-        x = x / ell
-        y = y / ell
+        if ell is not None:
+            x = x / ell
+            y = y / ell
 
         # Compute squared distance matrix using quadratic expansion
         x_norm = x.pow(2).sum(dim=-2, keepdim=True)

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -99,12 +99,6 @@ class Euclid(Manifold):
         res.clamp_min_(0)
         return res
 
-    @staticmethod
-    def linear_distance(x: Tensor, y: Tensor) -> Tensor:
-        dist = x.transpose(-1, -2).matmul(y)
-        dist.clamp_min_(0)
-        return dist
-
     @property
     def name(self):
         return 'Euclid(' + str(self.d) + ')'

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -83,8 +83,9 @@ class Euclid(Manifold):
         return x + y
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: Tensor = torch.ones(1, 1,
-                                                                1)) -> Tensor:
+    def distance(
+        x: Tensor, y: Tensor, ell: Optional[Tensor] = torch.ones(1, 1,
+                                                                 1)) -> Tensor:
         # Based on implementation here: https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/kernels/kernel.py
 
         #scale lengths by ell

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -127,10 +127,3 @@ class S3(Manifold):
         res = 2 * (1 - z)
         res.clamp_min_(0)
         return res
-
-    @staticmethod
-    def linear_distance(x: Tensor, y: Tensor) -> Tensor:
-        # distance: (x dot y)
-        res = x.transpose(-1, -2).matmul(y)
-        res.clamp_min_(0)
-        return res

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -121,7 +121,7 @@ class S3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: None = None) -> Tensor:
         # distance: 2 - 2 (x dot y)
         z = x.transpose(-1, -2).matmul(y)
         res = 2 * (1 - z)

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -121,7 +121,7 @@ class S3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: None = None) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Optional[None] = None) -> Tensor:
         # distance: 2 - 2 (x dot y)
         z = x.transpose(-1, -2).matmul(y)
         res = 2 * (1 - z)

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -147,7 +147,7 @@ class So3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell : None = None) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: None = None) -> Tensor:
         # distance: 4 - 4 (x dot y)^2
         z = x.transpose(-1, -2).matmul(y)
         res = 4 * (1 - z.square())

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -147,7 +147,7 @@ class So3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell : None = None) -> Tensor:
         # distance: 4 - 4 (x dot y)^2
         z = x.transpose(-1, -2).matmul(y)
         res = 4 * (1 - z.square())

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -147,7 +147,7 @@ class So3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: None = None) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Optional[None] = None) -> Tensor:
         # distance: 4 - 4 (x dot y)^2
         z = x.transpose(-1, -2).matmul(y)
         res = 4 * (1 - z.square())

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -153,10 +153,3 @@ class So3(Manifold):
         res = 4 * (1 - z.square())
         res.clamp_min_(0)
         return res
-
-    @staticmethod
-    def linear_distance(x: Tensor, y: Tensor) -> Tensor:
-        # distance: 2 (x dot y)^2
-        res = 2 * x.transpose(-1, -2).matmul(y).square()
-        res.clamp_min_(0)
-        return res

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -113,18 +113,3 @@ class Torus(Manifold):
         res = 2 * (d - z1_.transpose(-1, -2).matmul(z2_))
         res.clamp_min_(0)
         return res
-
-    @staticmethod
-    def linear_distance(x: Tensor, y: Tensor) -> Tensor:
-        # distance = cos(x - y)
-        # here we use the identity: cox(x-y) = cos(x)cos(y) + sin(x)sin(y)
-        d = x.shape[-2]
-        cx = torch.cos(x)
-        cy = torch.cos(y)
-        sx = torch.sin(x)
-        sy = torch.sin(y)
-        z1_ = torch.cat([cx, sx], dim=-2)
-        z2_ = torch.cat([cy, sy], dim=-2)
-        res = z1_.transpose(-1, -2).matmul(z2_)
-        res.clamp_min_(0)
-        return res

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -100,12 +100,14 @@ class Torus(Manifold):
         return x + y
 
     @staticmethod
-    def distance(
-        x: Tensor, y: Tensor, ell: Optional[Tensor] = torch.ones(1, 1,
-                                                                 1)) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Optional[Tensor] = None) -> Tensor:
         # distance = 2 - 2 cos(x-y)
         # here we use the identity: cox(x-y) = cos(x)cos(y) + sin(x)sin(y)
         d = x.shape[-2]
+
+        if ell is None:
+            ell = torch.ones(1, 1, 1)
+
         cx = torch.cos(x) / ell  #(... n x d x mx)
         cy = torch.cos(y) / ell
         sx = torch.sin(x) / ell

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -100,16 +100,18 @@ class Torus(Manifold):
         return x + y
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell : Tensor = torch.ones(1,1,1)) -> Tensor:
         # distance = 2 - 2 cos(x-y)
         # here we use the identity: cox(x-y) = cos(x)cos(y) + sin(x)sin(y)
         d = x.shape[-2]
-        cx = torch.cos(x)
-        cy = torch.cos(y)
-        sx = torch.sin(x)
-        sy = torch.sin(y)
-        z1_ = torch.cat([cx, sx], dim=-2)
-        z2_ = torch.cat([cy, sy], dim=-2)
-        res = 2 * (d - z1_.transpose(-1, -2).matmul(z2_))
+        cx = torch.cos(x)/ell #(... n x d x mx)
+        cy = torch.cos(y)/ell
+        sx = torch.sin(x)/ell
+        sy = torch.sin(y)/ell
+        z1_ = torch.cat([cx, sx], dim=-2) #(... n x 2d x mx)
+        z2_ = torch.cat([cy, sy], dim=-2) #(... n x 2d x mx)
+        const = d*(torch.square(ell**(-1))).mean(-2) # (1/n x 1/d x 1) -> (1/n x 1)
+        
+        res = 2 * (const[..., None] - z1_.transpose(-1, -2).matmul(z2_))
         res.clamp_min_(0)
         return res

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -100,18 +100,20 @@ class Torus(Manifold):
         return x + y
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell : Tensor = torch.ones(1,1,1)) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Tensor = torch.ones(1, 1,
+                                                                1)) -> Tensor:
         # distance = 2 - 2 cos(x-y)
         # here we use the identity: cox(x-y) = cos(x)cos(y) + sin(x)sin(y)
         d = x.shape[-2]
-        cx = torch.cos(x)/ell #(... n x d x mx)
-        cy = torch.cos(y)/ell
-        sx = torch.sin(x)/ell
-        sy = torch.sin(y)/ell
-        z1_ = torch.cat([cx, sx], dim=-2) #(... n x 2d x mx)
-        z2_ = torch.cat([cy, sy], dim=-2) #(... n x 2d x mx)
-        const = d*(torch.square(ell**(-1))).mean(-2) # (1/n x 1/d x 1) -> (1/n x 1)
-        
+        cx = torch.cos(x) / ell  #(... n x d x mx)
+        cy = torch.cos(y) / ell
+        sx = torch.sin(x) / ell
+        sy = torch.sin(y) / ell
+        z1_ = torch.cat([cx, sx], dim=-2)  #(... n x 2d x mx)
+        z2_ = torch.cat([cy, sy], dim=-2)  #(... n x 2d x mx)
+        const = d * (torch.square(ell**(-1))).mean(
+            -2)  # (1/n x 1/d x 1) -> (1/n x 1)
+
         res = 2 * (const[..., None] - z1_.transpose(-1, -2).matmul(z2_))
         res.clamp_min_(0)
         return res

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -100,8 +100,9 @@ class Torus(Manifold):
         return x + y
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: Tensor = torch.ones(1, 1,
-                                                                1)) -> Tensor:
+    def distance(
+        x: Tensor, y: Tensor, ell: Optional[Tensor] = torch.ones(1, 1,
+                                                                 1)) -> Tensor:
         # distance = 2 - 2 cos(x-y)
         # here we use the identity: cox(x-y) = cos(x)cos(y) + sin(x)sin(y)
         d = x.shape[-2]

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -112,7 +112,8 @@ class Torus(Manifold):
         sy = torch.sin(y) / ell
         z1_ = torch.cat([cx, sx], dim=-2)  #(... n x 2d x mx)
         z2_ = torch.cat([cy, sy], dim=-2)  #(... n x 2d x mx)
-        const = d * (torch.square(ell**(-1))).mean(
+
+        const = d * ell.square().reciprocal().mean(
             -2)  # (1/n x 1/d x 1) -> (1/n x 1)
 
         res = 2 * (const[..., None] - z1_.transpose(-1, -2).matmul(z2_))

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -1,0 +1,75 @@
+import numpy as np
+import torch
+from torch import optim
+import mgplvm as mgp
+import matplotlib.pyplot as plt
+
+torch.manual_seed(0)
+np.random.seed(0)
+
+torch.set_default_dtype(torch.float64)
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+else:
+    device = torch.device("cpu")
+
+
+def test_linear_ard():
+    """
+    test that svgplvm runs without explicit check for correctness
+    also test that burda log likelihood runs and is smaller than elbo
+    """
+    
+    x = np
+    
+    d = 2  # dims of latent space
+    n = 12  # number of neurons
+    m = 30  # number of conditions / time points
+    n_z = 5  # number of inducing points
+    n_samples = 1  # number of samples
+    
+    x = np.random.normal(0, 1, size = (n_samples, m, d)) #generate latents
+    C = np.random.normal(0, 1, size = (n, d)) #actoor matrix
+    Y = C @ x.transpose(0, 2, 1)
+    assert Y.shape == (n_samples, n, m)
+    
+    sigs = np.random.uniform(0, 0.5, size = n)
+    Y = Y + np.random.normal(0, np.tile(sigs[None, ..., None], (n_samples, 1, m))) #add noise
+    
+    # specify manifold, kernel and rdist
+    manif = mgp.manifolds.Euclid(m, d+2) #over-parameterize
+    lat_dist = mgp.rdist.ReLie(manif, m, n_samples, diagonal=True, initialization = 'fa')
+    kernel = mgp.kernels.Linear(n, d, ard = True, learn_scale = False)
+    lik = mgp.likelihoods.Gaussian(n)
+    lprior = mgp.lpriors.Uniform(manif)
+    z = manif.inducing_points(n, n_z)
+    mod = mgp.models.SvgpLvm(n,
+                             m,
+                             n_samples,
+                             z,
+                             kernel,
+                             lik,
+                             lat_dist,
+                             lprior,
+                             whiten=True).to(device)
+    
+    trained_mod = optimisers.svgp.fit(torch.tensor(Y).to(device),
+                                          mod,
+                                          optimizer=optim.Adam,
+                                          max_steps=200,
+                                          burnin=50,
+                                          n_mc=16,
+                                          lrate=5E-2,
+                                          print_every=50)
+
+    
+    ells = mod.kernel.ell
+    ells = np.sort(ells.detach().cpu().numpy()**(-1))
+    print(ells)
+
+    for i in range(2): #more than a standaard deeviaation away from the other ells
+        assert ells[d+i] > (ells[d-1]+np.std(ells[:d]))
+
+
+if __name__ == '__main__':
+    test_linear_ard()

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -14,17 +14,17 @@ else:
     device = torch.device("cpu")
 
 
-def gen_ard_data(d0=2, d=4, n=25, m=50, n_z=15, n_samples=1, lin = True):
+def gen_ard_data(d0=2, d=4, n=25, m=50, n_z=15, n_samples=1, lin=True):
     x = np.random.normal(0, 1, size=(n_samples, m, d0))  #generate latents
     C = np.random.normal(0, 1, size=(n, d0))  #actoor matrix
-    
+
     if lin:
         Y = C @ x.transpose(0, 2, 1)
         sigs = np.random.uniform(0, 0.25, size=n)
     else:
         Y = np.sin(1 * C @ x.transpose(0, 2, 1))
         sigs = np.random.uniform(0, 0.25, size=n)
-        
+
     assert Y.shape == (n_samples, n, m)
 
     Y = Y + np.random.normal(0, np.tile(sigs[None, ..., None],
@@ -50,7 +50,7 @@ def test_linear_ard():
                                initialization='fa',
                                Y=Y)
     kernel = mgp.kernels.Linear(n, d, ard=True, learn_scale=False)
-    lik = mgp.likelihoods.Gaussian(n, sigma = np.ones(n)*0.5)
+    lik = mgp.likelihoods.Gaussian(n, sigma=np.ones(n) * 0.5)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
@@ -76,9 +76,9 @@ def test_linear_ard():
     ells = np.sort(ells.detach().cpu().numpy())
     print('\n', ells)
 
-    for i in range(d - d0):  
+    for i in range(d - d0):
         #more than three standard deviations away from the other ells
-        assert ells[d0 + i] > (ells[d0 - 1] + 3*np.std(ells[:d0]))
+        assert ells[d0 + i] > (ells[d0 - 1] + 3 * np.std(ells[:d0]))
 
 
 def test_rbf_ard():
@@ -86,7 +86,7 @@ def test_rbf_ard():
     test that the RBF ARD functionality correctly discards the unwanted dimensions
     """
 
-    d0, d, n, m, n_z, n_samples, Y = gen_ard_data(lin = False)
+    d0, d, n, m, n_z, n_samples, Y = gen_ard_data(lin=False)
 
     # specify manifold, kernel and rdist
     manif = mgp.manifolds.Euclid(m, d)
@@ -103,7 +103,7 @@ def test_rbf_ard():
                                  d=d,
                                  ell_byneuron=False)
     print(d, kernel.ell.shape)
-    lik = mgp.likelihoods.Gaussian(n, sigma = np.ones(n)*0.25)
+    lik = mgp.likelihoods.Gaussian(n, sigma=np.ones(n) * 0.25)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
@@ -128,9 +128,9 @@ def test_rbf_ard():
     ells = np.sort(mod.kernel.ell.detach().cpu().numpy()[0, :])
     print('\n', ells)
 
-    for i in range(d - d0):  
+    for i in range(d - d0):
         #more than three standard deviations away from the other ells
-        assert ells[d0 + i] > (ells[d0 - 1] + 2*np.std(ells[:d0]))
+        assert ells[d0 + i] > (ells[d0 - 1] + 2 * np.std(ells[:d0]))
 
 
 if __name__ == '__main__':

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -50,7 +50,7 @@ def test_linear_ard():
                                initialization='fa',
                                Y=Y)
     kernel = mgp.kernels.Linear(n, d, ard=True, learn_scale=False)
-    lik = mgp.likelihoods.Gaussian(n, sigma=np.ones(n) * 0.5)
+    lik = mgp.likelihoods.Gaussian(n, sigma=torch.ones(n) * 0.5)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
@@ -103,7 +103,7 @@ def test_rbf_ard():
                                  d=d,
                                  ell_byneuron=False)
     print(d, kernel.ell.shape)
-    lik = mgp.likelihoods.Gaussian(n, sigma=np.ones(n) * 0.25)
+    lik = mgp.likelihoods.Gaussian(n, sigma=torch.ones(n) * 0.25)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -14,13 +14,19 @@ else:
     device = torch.device("cpu")
 
 
-def gen_ard_data(d0=2, d=4, n=15, m=30, n_z=5, n_samples=1):
+def gen_ard_data(d0=2, d=4, n=25, m=50, n_z=15, n_samples=1, lin = True):
     x = np.random.normal(0, 1, size=(n_samples, m, d0))  #generate latents
     C = np.random.normal(0, 1, size=(n, d0))  #actoor matrix
-    Y = C @ x.transpose(0, 2, 1)
+    
+    if lin:
+        Y = C @ x.transpose(0, 2, 1)
+        sigs = np.random.uniform(0, 0.25, size=n)
+    else:
+        Y = np.sin(1 * C @ x.transpose(0, 2, 1))
+        sigs = np.random.uniform(0, 0.25, size=n)
+        
     assert Y.shape == (n_samples, n, m)
 
-    sigs = np.random.uniform(0, 0.5, size=n)
     Y = Y + np.random.normal(0, np.tile(sigs[None, ..., None],
                                         (n_samples, 1, m)))  #add noise
 
@@ -40,11 +46,11 @@ def test_linear_ard():
                                m,
                                n_samples,
                                diagonal=True,
-                               sigma=0.2,
+                               sigma=0.3,
                                initialization='fa',
                                Y=Y)
     kernel = mgp.kernels.Linear(n, d, ard=True, learn_scale=False)
-    lik = mgp.likelihoods.Gaussian(n)
+    lik = mgp.likelihoods.Gaussian(n, sigma = np.ones(n)*0.5)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
@@ -60,19 +66,19 @@ def test_linear_ard():
     trained_mod = mgp.optimisers.svgp.fit(torch.tensor(Y).to(device),
                                           mod,
                                           optimizer=optim.Adam,
-                                          max_steps=300,
-                                          burnin=30,
+                                          max_steps=700,
+                                          burnin=50,
                                           n_mc=5,
-                                          lrate=7.5E-2,
+                                          lrate=20E-2,
                                           print_every=50)
 
     ells = (mod.kernel.input_scale)**(-1)
     ells = np.sort(ells.detach().cpu().numpy())
     print('\n', ells)
 
-    for i in range(
-            d - d0):  #more than a standard deviation away from the other ells
-        assert ells[d0 + i] > (ells[d0 - 1] + np.std(ells[:d0]))
+    for i in range(d - d0):  
+        #more than three standard deviations away from the other ells
+        assert ells[d0 + i] > (ells[d0 - 1] + 3*np.std(ells[:d0]))
 
 
 def test_rbf_ard():
@@ -80,15 +86,15 @@ def test_rbf_ard():
     test that the RBF ARD functionality correctly discards the unwanted dimensions
     """
 
-    d0, d, n, m, n_z, n_samples, Y = gen_ard_data()
+    d0, d, n, m, n_z, n_samples, Y = gen_ard_data(lin = False)
 
     # specify manifold, kernel and rdist
-    manif = mgp.manifolds.Euclid(m, d)  #over-parameterize
+    manif = mgp.manifolds.Euclid(m, d)
     lat_dist = mgp.rdist.ReLie(manif,
                                m,
                                n_samples,
                                diagonal=True,
-                               sigma=0.2,
+                               sigma=0.5,
                                initialization='fa',
                                Y=Y)
     kernel = mgp.kernels.QuadExp(n,
@@ -96,7 +102,8 @@ def test_rbf_ard():
                                  Y=Y,
                                  d=d,
                                  ell_byneuron=False)
-    lik = mgp.likelihoods.Gaussian(n)
+    print(d, kernel.ell.shape)
+    lik = mgp.likelihoods.Gaussian(n, sigma = np.ones(n)*0.25)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n,
@@ -112,21 +119,20 @@ def test_rbf_ard():
     trained_mod = mgp.optimisers.svgp.fit(torch.tensor(Y).to(device),
                                           mod,
                                           optimizer=optim.Adam,
-                                          max_steps=300,
-                                          burnin=30,
-                                          n_mc=5,
-                                          lrate=7.5E-2,
+                                          max_steps=700,
+                                          burnin=50,
+                                          n_mc=12,
+                                          lrate=15E-2,
                                           print_every=50)
 
-    ells = np.sort(mod.kernel.ell.detach().cpu().numpy()[:, 0])
+    ells = np.sort(mod.kernel.ell.detach().cpu().numpy()[0, :])
     print('\n', ells)
 
-    for i in range(
-            d -
-            d0):  #more than a standaard deeviaation away from the other ells
-        assert ells[d0 + i] > (ells[d0 - 1] + np.std(ells[:d0]))
+    for i in range(d - d0):  
+        #more than three standard deviations away from the other ells
+        assert ells[d0 + i] > (ells[d0 - 1] + 2*np.std(ells[:d0]))
 
 
 if __name__ == '__main__':
-    #test_linear_ard()
+    test_linear_ard()
     test_rbf_ard()

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -57,10 +57,10 @@ def test_linear_ard():
     trained_mod = mgp.optimisers.svgp.fit(torch.tensor(Y).to(device),
                                           mod,
                                           optimizer=optim.Adam,
-                                          max_steps=500,
-                                          burnin=50,
+                                          max_steps=300,
+                                          burnin=30,
                                           n_mc=5,
-                                          lrate=5E-2,
+                                          lrate=7.5E-2,
                                           print_every=50)
 
     

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -19,28 +19,35 @@ def test_linear_ard():
     test that svgplvm runs without explicit check for correctness
     also test that burda log likelihood runs and is smaller than elbo
     """
-    
+
     x = np
-    
+
     d0 = 2  # dims of true latent space
-    d = d0+2 # gplvm dim
+    d = d0 + 2  # gplvm dim
     n = 15  # number of neurons
     m = 30  # number of conditions / time points
     n_z = 5  # number of inducing points
     n_samples = 1  # number of samples
-    
-    x = np.random.normal(0, 1, size = (n_samples, m, d0)) #generate latents
-    C = np.random.normal(0, 1, size = (n, d0)) #actoor matrix
+
+    x = np.random.normal(0, 1, size=(n_samples, m, d0))  #generate latents
+    C = np.random.normal(0, 1, size=(n, d0))  #actoor matrix
     Y = C @ x.transpose(0, 2, 1)
     assert Y.shape == (n_samples, n, m)
-    
-    sigs = np.random.uniform(0, 0.5, size = n)
-    Y = Y + np.random.normal(0, np.tile(sigs[None, ..., None], (n_samples, 1, m))) #add noise
-    
+
+    sigs = np.random.uniform(0, 0.5, size=n)
+    Y = Y + np.random.normal(0, np.tile(sigs[None, ..., None],
+                                        (n_samples, 1, m)))  #add noise
+
     # specify manifold, kernel and rdist
-    manif = mgp.manifolds.Euclid(m, d) #over-parameterize
-    lat_dist = mgp.rdist.ReLie(manif, m, n_samples, diagonal=True, sigma = 0.2, initialization = 'fa', Y = Y)
-    kernel = mgp.kernels.Linear(n, d, ard = True, learn_scale = False)
+    manif = mgp.manifolds.Euclid(m, d)  #over-parameterize
+    lat_dist = mgp.rdist.ReLie(manif,
+                               m,
+                               n_samples,
+                               diagonal=True,
+                               sigma=0.2,
+                               initialization='fa',
+                               Y=Y)
+    kernel = mgp.kernels.Linear(n, d, ard=True, learn_scale=False)
     lik = mgp.likelihoods.Gaussian(n)
     lprior = mgp.lpriors.Uniform(manif)
     z = manif.inducing_points(n, n_z)
@@ -53,7 +60,7 @@ def test_linear_ard():
                              lat_dist,
                              lprior,
                              whiten=True).to(device)
-    
+
     trained_mod = mgp.optimisers.svgp.fit(torch.tensor(Y).to(device),
                                           mod,
                                           optimizer=optim.Adam,
@@ -63,13 +70,14 @@ def test_linear_ard():
                                           lrate=7.5E-2,
                                           print_every=50)
 
-    
     ells = mod.kernel.ell
     ells = np.sort(ells.detach().cpu().numpy()**(-1))
     print('\n', ells)
 
-    for i in range(d-d0): #more than a standaard deeviaation away from the other ells
-        assert ells[d0+i] > (ells[d0-1]+np.std(ells[:d0]))
+    for i in range(
+            d -
+            d0):  #more than a standaard deeviaation away from the other ells
+        assert ells[d0 + i] > (ells[d0 - 1] + np.std(ells[:d0]))
 
 
 if __name__ == '__main__':

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -167,7 +167,7 @@ def test_linear_kernel():
     y_ = torch.tensor(y).transpose(-1, -2)
     scale = np.ones((n))
     K = sklkernels.DotProduct(sigma_0=0)(x, y)
-    kernel = Linear(n, Euclid.distance, scale=scale)
+    kernel = Linear(n, d, scale=scale)
     K_ = kernel(x_, y_)[0].data.cpu().numpy()
     assert np.allclose(K_, K)
 

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -89,63 +89,6 @@ def test_s3_distance():
     assert torch.allclose(slow_dist, dist)
 
 
-def test_euclid_linear_distance():
-    mx = 8
-    my = 6
-    d = 3
-    x = torch.randn(2, 5, 1, d, mx)
-    y = torch.randn(2, 1, 4, d, my)
-    manif = manifolds.Euclid(10, d)
-    slow_dist = (x[..., None] * y[..., None, :]).sum(-3)
-    slow_dist.clamp_min_(0)
-    dist = manif.linear_distance(x, y)
-    assert torch.allclose(slow_dist, dist)
-
-
-def test_torus_linear_distance():
-    mx = 8
-    my = 6
-    d = 3
-    x = torch.randn(2, 5, 1, d, mx)
-    y = torch.randn(2, 1, 4, d, my)
-    manif = manifolds.Torus(10, d)
-    slow_dist = torch.cos(x[..., None] - y[..., None, :]).sum(-3)
-    slow_dist.clamp_min_(0)
-    dist = manif.linear_distance(x, y)
-    assert torch.allclose(slow_dist, dist)
-
-
-def test_so3_linear_distance():
-    mx = 8
-    my = 6
-    d = 4
-    x = torch.randn(2, 5, 1, d, mx)
-    x = x / (1e-20 + x.square().sum(-2, keepdim=True).sqrt())
-    y = torch.randn(2, 1, 4, d, my)
-    y = y / (1e-20 + y.square().sum(-2, keepdim=True).sqrt())
-    manif = manifolds.So3(10)
-    z = (x[..., None] * y[..., None, :]).sum(-3)
-    slow_dist = 2 * z.square()
-    slow_dist.clamp_min_(0)
-    dist = manif.linear_distance(x, y)
-    assert torch.allclose(slow_dist, dist)
-
-
-def test_s3_linear_distance():
-    mx = 8
-    my = 6
-    d = 4
-    x = torch.randn(2, 5, 1, d, mx)
-    x = x / (1e-20 + x.square().sum(-2, keepdim=True).sqrt())
-    y = torch.randn(2, 1, 4, d, my)
-    y = y / (1e-20 + y.square().sum(-2, keepdim=True).sqrt())
-    manif = manifolds.S3(10)
-    z = (x[..., None] * y[..., None, :]).sum(-3)
-    z.clamp_min_(0)
-    dist = manif.linear_distance(x, y)
-    assert torch.allclose(z, dist)
-
-
 def test_manifs_runs():
     m, d, n, n_z, n_samples = 10, 3, 5, 5, 2
     Y = np.random.normal(0, 1, (n_samples, n, m))
@@ -191,8 +134,4 @@ if __name__ == '__main__':
     test_torus_distance()
     test_so3_distance()
     test_s3_distance()
-    test_euclid_linear_distance()
-    test_torus_linear_distance()
-    test_so3_linear_distance()
-    test_s3_linear_distance()
     test_manifs_runs()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -124,7 +124,7 @@ def test_svgplvm_batching():
 
         est_elbos = [for_batch() for _ in range(500)]
         err = np.abs(elbo - np.mean(est_elbos)) / np.linalg.norm(est_elbos)
-        assert err < 1E-4
+        assert err < 1E-3
 
 
 def test_svgp_batching():
@@ -183,7 +183,7 @@ def test_svgp_batching():
 
         est_elbos = [for_batch() for _ in range(500)]
         err = np.abs(elbo - np.mean(est_elbos)) / np.linalg.norm(est_elbos)
-        assert err < 1e-4
+        assert err < 1e-3
 
 
 if __name__ == '__main__':

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -60,7 +60,7 @@ def test_GP_prior():
     #lprior = lpriors.Gaussian(manif)
 
     # generate model
-    likelihood = mgp.likelihoods.Gaussian(n, variance=np.square(sigma))
+    likelihood = mgp.likelihoods.Gaussian(n, sigma=sigma)
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n, m, n_samples, z, kernel, likelihood, lat_dist,
                              lprior).to(device)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -60,7 +60,7 @@ def test_GP_prior():
     #lprior = lpriors.Gaussian(manif)
 
     # generate model
-    likelihood = mgp.likelihoods.Gaussian(n, sigma=sigma)
+    likelihood = mgp.likelihoods.Gaussian(n, sigma=torch.Tensor(sigma))
     z = manif.inducing_points(n, n_z)
     mod = mgp.models.SvgpLvm(n, m, n_samples, z, kernel, likelihood, lat_dist,
                              lprior).to(device)


### PR DESCRIPTION
In this PR, we implement automatic relevance determination for linear kernels.
This is done by parameterizing `x = ell * x` where ell is a vector of parameters that can be learned (which actually have units of inverse length since they are priors over the slope for each latent).

We also include a test that makes sure appropriate length scales are learned for synthetic data.

Finally, we remove the linear_distance method for all manifolds since this is now computed internally in the linear kernel.