### PR TITLE
Update svgp tuning function

### DIFF
--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -45,6 +45,7 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
 
 
 class Gaussian(Likelihood):
+    name = "Gaussian"
 
     def __init__(self,
                  n: int,
@@ -64,11 +65,11 @@ class Gaussian(Likelihood):
         raise Exception("Gaussian likelihood not implemented")
 
     def sample(self, f_samps: Tensor) -> Tensor:
-        '''f is n_b x n x m'''
+        '''f is n_mc x n_samples x n x m'''
         prms = self.prms
         #sample from p(y|f)
         dist = torch.distributions.Normal(f_samps,
-                                          torch.sqrt(prms).reshape(1, -1, 1))
+                                          torch.sqrt(prms)[None, None, :, None])
         y_samps = dist.sample()
         return y_samps
 
@@ -102,6 +103,7 @@ class Gaussian(Likelihood):
 
 
 class Poisson(Likelihood):
+    name = "Poisson"
 
     def __init__(
             self,
@@ -182,6 +184,7 @@ class Poisson(Likelihood):
 
 
 class NegativeBinomial(Likelihood):
+    name = "Negative binomial"
 
     def __init__(self,
                  n: int,
@@ -219,7 +222,7 @@ class NegativeBinomial(Likelihood):
         total_count, c, d = self.prms
         rate = c[..., None] * f_samps + d[..., None]  #shift+scale
         rate = self.inv_link(rate) * self.binsize
-        dist = dists.NegativeBinomial(total_count[None, ..., None, None],
+        dist = dists.NegativeBinomial(total_count[None, None, ..., None],
                                       logits=rate)  #neg binom
         y_samps = dist.sample()  #sample observations
         return y_samps

--- a/tests/test_model_sampler.py
+++ b/tests/test_model_sampler.py
@@ -1,0 +1,76 @@
+import numpy as np
+import torch
+from torch import optim
+import mgplvm as mgp
+import matplotlib.pyplot as plt
+
+torch.manual_seed(1)
+np.random.seed(0)
+
+torch.set_default_dtype(torch.float64)
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+else:
+    device = torch.device("cpu")
+
+
+def test_sampling():
+    """
+    test that we can sample from a trained latent variable model
+    """
+    d = 3  # dims of latent space
+    n = 8  # number of neurons
+    m = 10  # number of conditions / time points
+    n_z = 5  # number of inducing points
+    n_mc = 16
+    n_samples = 2  # number of samples
+    gen = mgp.syndata.Gen(mgp.syndata.Euclid(d),
+                          n,
+                          m,
+                          variability=0.25,
+                          n_samples=n_samples)
+    Y = gen.gen_data()
+    data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
+
+    for i, lik in enumerate([
+            mgp.likelihoods.Gaussian(n),
+            mgp.likelihoods.Poisson(n),
+            mgp.likelihoods.NegativeBinomial(n)
+    ]):
+
+        # specify manifold, kernel and rdist
+        manif = mgp.manifolds.Euclid(m, d)
+        lat_dist = mgp.rdist.ReLie(manif, m, n_samples, diagonal=False)
+        kernel = mgp.kernels.QuadExp(n, manif.distance)
+        lprior = mgp.lpriors.Uniform(manif)
+        z = manif.inducing_points(n, n_z)
+        mod = mgp.models.SvgpLvm(n,
+                                 m,
+                                 n_samples,
+                                 z,
+                                 kernel,
+                                 lik,
+                                 lat_dist,
+                                 lprior,
+                                 whiten=True).to(device)
+
+        # train model
+        mgp.optimisers.svgp.fit(data,
+                                mod,
+                                optimizer=optim.Adam,
+                                max_steps=5,
+                                burnin=5 / 2E-2,
+                                n_mc=16,
+                                lrate=5E-2,
+                                print_every=1000)
+
+        #sample from the model
+        query = mod.lat_dist.prms[0].detach().transpose(
+            -1, -2)  #(n_samples, m, d) -> (n_samples, d, m)
+        y_samps = mod.svgp.sample(query, n_mc=n_mc).cpu().numpy()
+        print('\n', i, lik.name, y_samps.shape)
+        assert y_samps.shape == (n_mc, n_samples, n, m)
+
+
+if __name__ == '__main__':
+    test_sampling()


### PR DESCRIPTION
In this PR, I update the svgp 'tuning' function to be compatible with our recent restructuring.
Note that this function has also been relabelled as 'sample'  since that it really what it does -- drawing n_mc samples from the full p(Y | X).

This PR should be merged after #37 and addresses issue #38