### PR TITLE
Initialization, likelihood.dist_mean() and misc edits

### DIFF
--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -121,7 +121,7 @@ def load_model(params):
     elif params['likelihood'] == 'Poisson':
         likelihood = likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':
-        likelihood = likelihoods.NegativeBinomial(n)
+        likelihood = likelihoods.NegativeBinomial(n, Y = params['Y'])
 
     #### specify inducing points ####
     z = manif.inducing_points(n, n_z)

--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -117,7 +117,7 @@ def load_model(params):
     #### specify likelihood ####
     if params['likelihood'] == 'Gaussian':
         likelihood: Likelihood = likelihoods.Gaussian(
-            n, sigma=params['lik_gauss_std'])
+            n, sigma=params['lik_gauss_std'], Y = params['Y'], d = d)
     elif params['likelihood'] == 'Poisson':
         likelihood = likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':

--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -117,11 +117,11 @@ def load_model(params):
     #### specify likelihood ####
     if params['likelihood'] == 'Gaussian':
         likelihood: Likelihood = likelihoods.Gaussian(
-            n, sigma=params['lik_gauss_std'], Y = params['Y'], d = d)
+            n, sigma=params['lik_gauss_std'], Y=params['Y'], d=d)
     elif params['likelihood'] == 'Poisson':
         likelihood = likelihoods.Poisson(n)
     elif params['likelihood'] == 'NegBinom':
-        likelihood = likelihoods.NegativeBinomial(n, Y = params['Y'])
+        likelihood = likelihoods.NegativeBinomial(n, Y=params['Y'])
 
     #### specify inducing points ####
     z = manif.inducing_points(n, n_z)

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -62,12 +62,12 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
         self.ard = (d is not None)
         if ell is None:
             if d is None:
-                _ell = inv_softplus(2*torch.ones(n,))
+                _ell = inv_softplus(2 * torch.ones(n,))
             elif ell_byneuron:
                 assert (d is not None)
-                _ell = inv_softplus(2*torch.ones(n, d))
+                _ell = inv_softplus(2 * torch.ones(n, d))
             else:
-                _ell = inv_softplus(2*torch.ones(1, d))
+                _ell = inv_softplus(2 * torch.ones(1, d))
         else:
             if d is not None:
                 assert ell.shape[-1] == d

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -62,12 +62,12 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
         self.ard = (d is not None)
         if ell is None:
             if d is None:
-                _ell = inv_softplus(torch.ones(n,))
+                _ell = inv_softplus(2*torch.ones(n,))
             elif ell_byneuron:
                 assert (d is not None)
-                _ell = inv_softplus(torch.ones(n, d))
+                _ell = inv_softplus(2*torch.ones(n, d))
             else:
-                _ell = inv_softplus(torch.ones(1, d))
+                _ell = inv_softplus(2*torch.ones(1, d))
         else:
             if d is not None:
                 assert ell.shape[-1] == d

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -95,6 +95,23 @@ class Gaussian(Likelihood):
     def log_prob(self, y):
         raise Exception("Gaussian likelihood not implemented")
 
+    def dist(self, fs: Tensor):
+        """
+        Parameters
+        ----------
+        fs : Tensor
+            GP mean function values (n_mc x n_samples x n x m)
+
+        Returns
+        -------
+        dist : distribution
+            resulting Gaussian distributions
+        """
+        prms = self.prms
+        dist = torch.distributions.Normal(fs,
+                                          torch.sqrt(prms)[None, None, :, None])
+        return dist
+
     def sample(self, f_samps: Tensor) -> Tensor:
         """
         Parameters
@@ -107,10 +124,8 @@ class Gaussian(Likelihood):
         y_samps : Tensor
             samples from the resulting Gaussian distributions (n_mc x n_samples x n x m)
         """
-        prms = self.prms
+        dist = self.dist(f_samps)
         #sample from p(y|f)
-        dist = torch.distributions.Normal(f_samps,
-                                          torch.sqrt(prms)[None, None, :, None])
         y_samps = dist.sample()
         return y_samps
 

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -25,7 +25,7 @@ def id_link(x):
     return x
 
 
-def FA_init(Y, d):
+def FA_init(Y, d: Optional[int] = None):
     n_samples, n, m = Y.shape
     if d is None:
         d = int(np.round(d / 4))
@@ -72,7 +72,7 @@ class Gaussian(Likelihood):
             if Y is None:
                 sigma = 1 * torch.ones(n,)
             else:
-                sigma = FA_init(Y, d)
+                sigma = FA_init(Y, d=d)
         self._sigma = nn.Parameter(data=sigma, requires_grad=learn_sigma)
 
     @property
@@ -106,7 +106,7 @@ class Gaussian(Likelihood):
         y_samps = dist.sample()
         return y_samps
 
-    def dist_mean(self, fs):
+    def dist_mean(self, fs: Tensor):
         """
         Parameters
         ----------
@@ -182,7 +182,7 @@ class Poisson(Likelihood):
         p = dists.Poisson(lamb)
         return p.log_prob(y[None, ..., None])
 
-    def dist(self, fs):
+    def dist(self, fs: Tensor):
         """
         Parameters
         ----------
@@ -199,7 +199,7 @@ class Poisson(Likelihood):
         dist = torch.distributions.Poisson(lambd)
         return dist
 
-    def sample(self, f_samps):
+    def sample(self, f_samps: Tensor):
         """
         Parameters
         ----------
@@ -215,7 +215,7 @@ class Poisson(Likelihood):
         y_samps = dist.sample()
         return y_samps
 
-    def dist_mean(self, fs):
+    def dist_mean(self, fs: Tensor):
         """
         Parameters
         ----------
@@ -315,7 +315,7 @@ class NegativeBinomial(Likelihood):
             self.total_count)
         return total_count, self.c, self.d
 
-    def dist(self, fs):
+    def dist(self, fs: Tensor):
         """
         Parameters
         ----------
@@ -334,7 +334,7 @@ class NegativeBinomial(Likelihood):
                                       logits=rate)  #neg binom
         return dist
 
-    def sample(self, f_samps):
+    def sample(self, f_samps: Tensor):
         """
         Parameters
         ----------
@@ -350,7 +350,7 @@ class NegativeBinomial(Likelihood):
         y_samps = dist.sample()  #sample observations
         return y_samps
 
-    def dist_mean(self, fs):
+    def dist_mean(self, fs: Tensor):
         """
         Parameters
         ----------

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -28,7 +28,7 @@ def id_link(x):
 def FA_init(Y, d: Optional[int] = None):
     n_samples, n, m = Y.shape
     if d is None:
-        d = int(np.round(d / 4))
+        d = int(np.round(n / 4))
     pca = decomposition.FactorAnalysis(n_components=d)
     Y = Y.transpose(0, 2, 1).reshape(n_samples * m, n)
     mudata = pca.fit_transform(Y)  #m*n_samples x d
@@ -53,6 +53,14 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
 
     @abc.abstractstaticmethod
     def sample(self, x: Tensor):
+        pass
+
+    @abc.abstractstaticmethod
+    def dist(self, x: Tensor):
+        pass
+
+    @abc.abstractstaticmethod
+    def dist_mean(self, x: Tensor):
         pass
 
 

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -33,10 +33,11 @@ class Euclid(Manifold):
                 print('user must provide data for FA initialization')
             else:
                 n = Y.shape[1]
-                pca = decomposition.FactorAnalysis(n_components=d)
+                #pca = decomposition.FactorAnalysis(n_components=d)
+                pca = decomposition.PCA(n_components=d)
                 Y = Y.transpose(0, 2, 1).reshape(n_samples * m, n)
                 mudata = pca.fit_transform(Y)  #m*n_samples x d
-                mudata = mudata / np.std(mudata, axis=0,
+                mudata = 0.5 * mudata / np.std(mudata, axis=0,
                                          keepdims=True)  #normalize
                 mudata = mudata.reshape(n_samples, m, d)
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -33,8 +33,8 @@ class Euclid(Manifold):
                 print('user must provide data for FA initialization')
             else:
                 n = Y.shape[1]
-                #pca = decomposition.FactorAnalysis(n_components=d)
-                pca = decomposition.PCA(n_components=d)
+                pca = decomposition.FactorAnalysis(n_components=d)
+                #pca = decomposition.PCA(n_components=d)
                 Y = Y.transpose(0, 2, 1).reshape(n_samples * m, n)
                 mudata = pca.fit_transform(Y)  #m*n_samples x d
                 mudata = 0.5 * mudata / np.std(mudata, axis=0,

--- a/mgplvm/manifolds/euclid.py
+++ b/mgplvm/manifolds/euclid.py
@@ -38,7 +38,7 @@ class Euclid(Manifold):
                 Y = Y.transpose(0, 2, 1).reshape(n_samples * m, n)
                 mudata = pca.fit_transform(Y)  #m*n_samples x d
                 mudata = 0.5 * mudata / np.std(mudata, axis=0,
-                                         keepdims=True)  #normalize
+                                               keepdims=True)  #normalize
                 mudata = mudata.reshape(n_samples, m, d)
                 return torch.tensor(mudata, dtype=torch.get_default_dtype())
         elif initialization in ['random', 'Random']:

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -168,7 +168,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
                query: Tensor,
                n_mc: int = 1000,
                square: bool = False,
-               noise: bool = False):
+               noise: bool = True):
         """
         Parameters
         ----------

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -164,7 +164,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         return lik, prior_kl
 
-    def sample(self, query: Tensor, n_mc: int = 1000, square: bool = False):
+    def sample(self, query: Tensor, n_mc: int = 1000, square: bool = False, noise: bool = False):
         """
         Parameters
         ----------
@@ -174,6 +174,8 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
             numper of samples to return
         square : bool
             determines whether to square the output
+        noise : bool
+            determines whether we also sample explicitly from the noise model or simply return samples of the mean
 
         Returns
         -------
@@ -190,11 +192,16 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         #sample from p(f|u)
         dist = Normal(mu, torch.sqrt(v))
+        
         f_samps = dist.sample((n_mc,))  #n_mc x n_samples x n x m
 
-        #sample from observation function p(y|f)
-        y_samps = self.likelihood.sample(f_samps)  #n_mc x n_samples x n x m
-
+        if noise:
+            #sample from observation function p(y|f)
+            y_samps = self.likelihood.sample(f_samps)  #n_mc x n_samples x n x m
+        else:
+            #compute mean observations mu(f) for each f
+            y_samps = self.likelihood.dist_mean(f_samps)  #n_mc x n_samples x n x m
+            
         if square:
             y_samps = y_samps**2
 

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -164,7 +164,11 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         return lik, prior_kl
 
-    def sample(self, query: Tensor, n_mc: int = 1000, square: bool = False, noise: bool = False):
+    def sample(self,
+               query: Tensor,
+               n_mc: int = 1000,
+               square: bool = False,
+               noise: bool = False):
         """
         Parameters
         ----------
@@ -192,7 +196,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
 
         #sample from p(f|u)
         dist = Normal(mu, torch.sqrt(v))
-        
+
         f_samps = dist.sample((n_mc,))  #n_mc x n_samples x n x m
 
         if noise:
@@ -200,8 +204,9 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
             y_samps = self.likelihood.sample(f_samps)  #n_mc x n_samples x n x m
         else:
             #compute mean observations mu(f) for each f
-            y_samps = self.likelihood.dist_mean(f_samps)  #n_mc x n_samples x n x m
-            
+            y_samps = self.likelihood.dist_mean(
+                f_samps)  #n_mc x n_samples x n x m
+
         if square:
             y_samps = y_samps**2
 

--- a/mgplvm/syndata/gen_data.py
+++ b/mgplvm/syndata/gen_data.py
@@ -340,13 +340,14 @@ class Gen():
                 self.params['l']))  # nman x n_samples x n x m
         Ks = np.exp(-0.5 * ds_sqr)  # nman x n_samples x n x m
         K = np.prod(Ks, axis=0)  # n_samples x n x m
+        n_samples, n, m = K.shape
         fs = self.params['alpha'] * K + self.params['beta']
 
         ### Generating according to p(Y | F)
         if mode == 'Gaussian':
             # add Gaussian noise
             sigma = self.params['sigma'] if sigma is None else sigma
-            noise = np.random.normal(0, np.repeat(sigma, self.m, axis=1))
+            noise = np.random.normal(0, np.repeat(np.repeat(sigma[None, ...], m, axis=-1), n_samples, axis = 0))
             self.Y = fs + noise
         elif mode == 'Poisson':  # Poisson spiking
             max_activity = np.mean(np.amax(fs, axis=1))

--- a/mgplvm/syndata/gen_data.py
+++ b/mgplvm/syndata/gen_data.py
@@ -342,13 +342,17 @@ class Gen():
         K = np.prod(Ks, axis=0)  # n_samples x n x m
         n_samples, n, m = K.shape
         fs = self.params['alpha'] * K + self.params['beta']
-        self.fs = fs #store denoised activities
+        self.fs = fs  #store denoised activities
 
         ### Generating according to p(Y | F)
         if mode == 'Gaussian':
             # add Gaussian noise
             sigma = self.params['sigma'] if sigma is None else sigma
-            noise = np.random.normal(0, np.repeat(np.repeat(sigma[None, ...], m, axis=-1), n_samples, axis = 0))
+            noise = np.random.normal(
+                0,
+                np.repeat(np.repeat(sigma[None, ...], m, axis=-1),
+                          n_samples,
+                          axis=0))
             self.Y = fs + noise
         elif mode == 'Poisson':  # Poisson spiking
             max_activity = np.mean(np.amax(fs, axis=1))

--- a/mgplvm/syndata/gen_data.py
+++ b/mgplvm/syndata/gen_data.py
@@ -342,6 +342,7 @@ class Gen():
         K = np.prod(Ks, axis=0)  # n_samples x n x m
         n_samples, n, m = K.shape
         fs = self.params['alpha'] * K + self.params['beta']
+        self.fs = fs #store denoised activities
 
         ### Generating according to p(Y | F)
         if mode == 'Gaussian':

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -38,31 +38,53 @@ def test_euclid_distance():
     mx = 8
     my = 6
     d = 3
-    x = torch.randn(2, 5, 1, d, mx)
-    y = torch.randn(2, 1, 4, d, my)
-    
+    #x = torch.randn(2, 5, 1, d, mx)
+    #y = torch.randn(2, 1, 4, d, my)
     x = torch.randn(n_mc, n_samples, n, d, mx)
     y = torch.randn(n_mc, n_samples, n, d, my)
-    ell = torch.ones(n, d, 1) + torch.randn(n, d, 1)*0.1
+    
+    ell0 = torch.ones(n, d, 1) + torch.randn(n, d, 1)*0.1
+    ell1 = torch.ones(1, d, 1) + torch.randn(1, d, 1)*0.1
+    ell2 = torch.ones(n, 1, 1) + torch.randn(n, 1, 1)*0.1
+    ell3 = None
     
     manif = manifolds.Euclid(10, d)
-    slow_dist = (torch.square(x[..., None] - y[..., None, :])/ell[..., None]**2).sum(-3)
-    slow_dist.clamp_min(0)
-    dist = manif.distance(x, y, ell = ell)
-    assert torch.allclose(slow_dist, dist)
+    for ell in [ell0, ell1, ell2, ell3]:
+        if ell is None:
+            slow_dist = torch.square(x[..., None] - y[..., None, :]).sum(-3)
+        else:
+            slow_dist = (torch.square(x[..., None] - y[..., None, :])/ell[..., None]**2).sum(-3)
+        slow_dist.clamp_min(0)
+        dist = manif.distance(x, y, ell = ell)
+        assert torch.allclose(slow_dist, dist)
 
 
 def test_torus_distance():
+    n_mc = 7
+    n_samples = 2
+    n = 5
     mx = 8
     my = 6
     d = 3
-    x = torch.randn(2, 5, 1, d, mx)
-    y = torch.randn(2, 1, 4, d, my)
+    #x = torch.randn(2, 5, 1, d, mx)
+    #y = torch.randn(2, 1, 4, d, my)
+    x = torch.randn(n_mc, n_samples, n, d, mx)
+    y = torch.randn(n_mc, n_samples, n, d, my)
+    
+    ell0 = torch.ones(n, d, 1) + torch.randn(n, d, 1)*0.1
+    ell1 = torch.ones(1, d, 1) + torch.randn(1, d, 1)*0.1
+    ell2 = torch.ones(n, 1, 1) + torch.randn(n, 1, 1)*0.1
+    ell3 = None
+    
     manif = manifolds.Torus(10, d)
-    slow_dist = (2 - 2 * torch.cos(x[..., None] - y[..., None, :])).sum(-3)
-    slow_dist.clamp_min(0)
-    dist = manif.distance(x, y)
-    assert torch.allclose(slow_dist, dist)
+    for ell in [ell0, ell1, ell2, ell3]:
+        if ell is None:
+            slow_dist = (2 - 2 * torch.cos(x[..., None] - y[..., None, :])).sum(-3)
+        else:
+            slow_dist = ((2 - 2 * torch.cos(x[..., None] - y[..., None, :]))/ell[..., None]**2).sum(-3)
+        slow_dist.clamp_min(0)
+        dist = manif.distance(x, y, ell = ell)
+        assert torch.allclose(slow_dist, dist)
 
 
 def test_so3_distance():

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -32,15 +32,23 @@ def test_s3_dimensions():
 
 
 def test_euclid_distance():
+    n_mc = 7
+    n_samples = 2
+    n = 5
     mx = 8
     my = 6
     d = 3
     x = torch.randn(2, 5, 1, d, mx)
     y = torch.randn(2, 1, 4, d, my)
+    
+    x = torch.randn(n_mc, n_samples, n, d, mx)
+    y = torch.randn(n_mc, n_samples, n, d, my)
+    ell = torch.ones(n, d, 1) + torch.randn(n, d, 1)*0.1
+    
     manif = manifolds.Euclid(10, d)
-    slow_dist = torch.square(x[..., None] - y[..., None, :]).sum(-3)
+    slow_dist = (torch.square(x[..., None] - y[..., None, :])/ell[..., None]**2).sum(-3)
     slow_dist.clamp_min(0)
-    dist = manif.distance(x, y)
+    dist = manif.distance(x, y, ell = ell)
     assert torch.allclose(slow_dist, dist)
 
 

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -42,20 +42,21 @@ def test_euclid_distance():
     #y = torch.randn(2, 1, 4, d, my)
     x = torch.randn(n_mc, n_samples, n, d, mx)
     y = torch.randn(n_mc, n_samples, n, d, my)
-    
-    ell0 = torch.ones(n, d, 1) + torch.randn(n, d, 1)*0.1
-    ell1 = torch.ones(1, d, 1) + torch.randn(1, d, 1)*0.1
-    ell2 = torch.ones(n, 1, 1) + torch.randn(n, 1, 1)*0.1
+
+    ell0 = torch.ones(n, d, 1) + torch.randn(n, d, 1) * 0.1
+    ell1 = torch.ones(1, d, 1) + torch.randn(1, d, 1) * 0.1
+    ell2 = torch.ones(n, 1, 1) + torch.randn(n, 1, 1) * 0.1
     ell3 = None
-    
+
     manif = manifolds.Euclid(10, d)
     for ell in [ell0, ell1, ell2, ell3]:
         if ell is None:
             slow_dist = torch.square(x[..., None] - y[..., None, :]).sum(-3)
         else:
-            slow_dist = (torch.square(x[..., None] - y[..., None, :])/ell[..., None]**2).sum(-3)
+            slow_dist = (torch.square(x[..., None] - y[..., None, :]) /
+                         ell[..., None]**2).sum(-3)
         slow_dist.clamp_min(0)
-        dist = manif.distance(x, y, ell = ell)
+        dist = manif.distance(x, y, ell=ell)
         assert torch.allclose(slow_dist, dist)
 
 
@@ -70,20 +71,22 @@ def test_torus_distance():
     #y = torch.randn(2, 1, 4, d, my)
     x = torch.randn(n_mc, n_samples, n, d, mx)
     y = torch.randn(n_mc, n_samples, n, d, my)
-    
-    ell0 = torch.ones(n, d, 1) + torch.randn(n, d, 1)*0.1
-    ell1 = torch.ones(1, d, 1) + torch.randn(1, d, 1)*0.1
-    ell2 = torch.ones(n, 1, 1) + torch.randn(n, 1, 1)*0.1
+
+    ell0 = torch.ones(n, d, 1) + torch.randn(n, d, 1) * 0.1
+    ell1 = torch.ones(1, d, 1) + torch.randn(1, d, 1) * 0.1
+    ell2 = torch.ones(n, 1, 1) + torch.randn(n, 1, 1) * 0.1
     ell3 = None
-    
+
     manif = manifolds.Torus(10, d)
     for ell in [ell0, ell1, ell2, ell3]:
         if ell is None:
-            slow_dist = (2 - 2 * torch.cos(x[..., None] - y[..., None, :])).sum(-3)
+            slow_dist = (2 -
+                         2 * torch.cos(x[..., None] - y[..., None, :])).sum(-3)
         else:
-            slow_dist = ((2 - 2 * torch.cos(x[..., None] - y[..., None, :]))/ell[..., None]**2).sum(-3)
+            slow_dist = ((2 - 2 * torch.cos(x[..., None] - y[..., None, :])) /
+                         ell[..., None]**2).sum(-3)
         slow_dist.clamp_min(0)
-        dist = manif.distance(x, y, ell = ell)
+        dist = manif.distance(x, y, ell=ell)
         assert torch.allclose(slow_dist, dist)
 
 

--- a/tests/test_model_sampler.py
+++ b/tests/test_model_sampler.py
@@ -31,7 +31,7 @@ def test_sampling():
                           variability=0.25,
                           n_samples=n_samples)
     Y = gen.gen_data()
-    Y = Y+np.amin(Y)
+    Y = Y + np.amin(Y)
     data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
 
     for i, lik in enumerate([
@@ -87,7 +87,7 @@ def test_sampling():
         frac = leqs.sum() / (leqs.shape[0] * leqs.shape[1] * leqs.shape[2])
         print(frac)
 
-        assert frac > 0.9 #this should be true for a trained model but might not be robust for an untrained model
+        assert frac > 0.9  #this should be true for a trained model but might not be robust for an untrained model
 
 
 if __name__ == '__main__':

--- a/tests/test_model_sampler.py
+++ b/tests/test_model_sampler.py
@@ -31,6 +31,7 @@ def test_sampling():
                           variability=0.25,
                           n_samples=n_samples)
     Y = gen.gen_data()
+    Y = Y+np.amin(Y)
     data = torch.tensor(Y, device=device, dtype=torch.get_default_dtype())
 
     for i, lik in enumerate([
@@ -59,7 +60,7 @@ def test_sampling():
         mgp.optimisers.svgp.fit(data,
                                 mod,
                                 optimizer=optim.Adam,
-                                max_steps=5,
+                                max_steps=50,
                                 burnin=5 / 2E-2,
                                 n_mc=n_mc,
                                 lrate=5E-2,
@@ -86,7 +87,7 @@ def test_sampling():
         frac = leqs.sum() / (leqs.shape[0] * leqs.shape[1] * leqs.shape[2])
         print(frac)
 
-        assert frac > 0.5
+        assert frac > 0.9 #this should be true for a trained model but might not be robust for an untrained model
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this PR, we do a couple of different things:

___initialization___
Provide the option to initialize the Gaussian noise variance from data using FA
Provide the option to initialize the NegBinom total_counts (r) from data. Here we assume that p=0.5 such that mu = r and set r = mean(Y). Other suggestions are welcome.
I noticed that our Euclidean initialization occasionally fragmented and therefore (i) set ell0=2 by default + (ii) scaled the initial FA latents to circumvent this (this prevents distances between groups from approaching ell).

___likelihood.dist_mean()___
I added a .mean() method to our likelihoods which takes as input a set of GP function values. This enables us to compute distributions over tuning curves for likelihoods where the mean is non-linear in the GP function values.
I also added a 'noise=True/False' flag to svgp.sample which samples either Y|GP (as before) or mu|GP (using dist_mean()).

___misc___
Fixed a bug in gen_data.
Updated the manifold.distance tests to include various options for ell.