### PR TITLE
Update crossvalidation to correctly weight the svgp prior and allow for sampled predictions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../../mgplvm'))
 
 # -- Project information -----------------------------------------------------

--- a/examples/torus_svgp.py
+++ b/examples/torus_svgp.py
@@ -5,6 +5,7 @@ import mgplvm
 from mgplvm import kernels, rdist, models, training
 from mgplvm.manifolds import Torus, Euclid, So3
 import matplotlib.pyplot as plt
+
 torch.set_default_dtype(torch.float64)
 if torch.cuda.is_available():
     device = torch.device("cuda")

--- a/mgplvm/crossval/construct_model.py
+++ b/mgplvm/crossval/construct_model.py
@@ -31,7 +31,7 @@ def model_params(n, m, d, n_z, n_samples, **kwargs):
         'RBF_scale': None,
         'RBF_ell': None,
         'arp_p': 1,
-        'arp_eta': np.ones(d) * 0.3,
+        'arp_eta': np.ones(d) * 1,
         'arp_learn_eta': True,
         'arp_learn_c': False,
         'arp_learn_phi': True,

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -65,7 +65,8 @@ def train_cv(mod,
         N1 = np.random.permutation(np.arange(n))[:nn_train]
     split = {'Y': Y, 'N1': N1, 'T1': T1}
 
-    train_ps1 = update_params(train_ps, batch_pool=T1)
+    #mod.m, mod.svgp.m = len(T1), len(T1)
+    train_ps1 = update_params(train_ps, batch_pool=T1, prior_m = len(T1))
 
     #print(Y.shape, mod.lat_dist.prms[0].shape, mod.lat_dist.prms[1].shape)
 
@@ -77,7 +78,8 @@ def train_cv(mod,
         grad[:, T1, ...] *= 0
         return grad
 
-    train_ps2 = update_params(train_ps, neuron_idxs=N1, mask_Ts=mask_Ts)
+    #mod.m, mod.svgp.m = m, m
+    train_ps2 = update_params(train_ps, neuron_idxs=N1, mask_Ts=mask_Ts, prior_m = None)
 
     for p in mod.parameters():  #no gradients for the remaining parameters
         p.requires_grad = False
@@ -93,7 +95,7 @@ def train_cv(mod,
     return mod, split
 
 
-def test_cv(mod, split, device, n_mc=32, Print=False):
+def test_cv(mod, split, device, n_mc=32, Print=False, sample_mean = False):
     Y, T1, N1 = split['Y'], split['T1'], split['N1']
     n_samples, n, m = Y.shape
 
@@ -106,20 +108,37 @@ def test_cv(mod, split, device, n_mc=32, Print=False):
     latents = mod.lat_dist.prms[0].detach()[:, T2,
                                             ...]  #latent means (ntrial, T2, d)
     query = latents.transpose(-1, -2)  #(ntrial, d, m)
-    Ypred, var = mod.svgp.predict(query[None, ...], False)
-    Ypred = Ypred.detach().cpu().numpy()[0][:, N2, :]  #(ntrial, N2, T2)
-    MSE = np.mean((Ypred - Ytest)**2)
+    
+    if sample_mean: #we don't have a closed form mean prediction so sample from (mu|GP) and average instead
+        #n_mc x n_samples x N x d
+        Ypred = mod.svgp.sample(query, n_mc = n_mc, noise = False)
+        Ypred = Ypred.mean(0).cpu().numpy()[:, N2, :] #(ntrial x N2 x T2)
+    else:
+        Ypred, var = mod.svgp.predict(query[None, ...], False)
+        Ypred = Ypred.detach().cpu().numpy()[0][:, N2, :]  #(ntrial, N2, T2)
+    MSE_vals = np.mean((Ypred - Ytest)**2, axis = (0, -1))
+    MSE = np.mean(MSE_vals) #standard MSE
+    norm_MSE = MSE_vals / np.var(Ytest, axis = (0, -1)) #normalize by neuron variance
+    norm_MSE = np.mean(norm_MSE)
 
     var_cap = 1 - np.var(Ytest - Ypred) / np.var(Ytest)
 
     ### compute crossvalidated log likelihood ###
-    #(n_mc, n_samples, n), (n_mc, n_samples)
+    #mold = mod.m
+    #mod.m = len(T2) #use correct scaling factor for the test data
+    #mod.svgp.m = len(T2)
+    
     data = torch.tensor(Y, device=device)
+    #(n_mc, n_samples, n), (n_mc, n_samples)
     svgp_elbo, kl = mod.elbo(data[:, :, T2],
                              n_mc,
                              batch_idxs=T2,
-                             neuron_idxs=N2)
-
+                             neuron_idxs=N2,
+                            m = len(T2))
+    
+    #mod.m = mold #restore original scaling factor
+    #mod.svgp.m = mold
+    
     svgp_elbo = svgp_elbo.sum(-1)  #(n_mc)
     LLs = svgp_elbo - kl  # LL for each batch (n_mc, )
     LL = (torch.logsumexp(LLs, 0) - np.log(n_mc)).detach().cpu().numpy()
@@ -130,4 +149,4 @@ def test_cv(mod, split, device, n_mc=32, Print=False):
         print('var_cap', var_cap)
         print('MSE', MSE, np.sqrt(np.mean(np.var(Ytest, axis=-1))))
 
-    return MSE, LL, var_cap
+    return MSE, LL, var_cap, norm_MSE

--- a/mgplvm/crossval/crossval.py
+++ b/mgplvm/crossval/crossval.py
@@ -2,6 +2,7 @@ import numpy as np
 import copy
 import torch
 from .train_model import train_model
+
 torch.set_default_dtype(torch.float64)
 
 

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -46,6 +46,6 @@ def train_model(mod, data, params):
                                       stop=params['callback'],
                                       neuron_idxs=params['neuron_idxs'],
                                       mask_Ts=params['mask_Ts'],
-                                     prior_m=params['prior_m']),
+                                      prior_m=params['prior_m']),
 
     return trained_mod

--- a/mgplvm/crossval/train_model.py
+++ b/mgplvm/crossval/train_model.py
@@ -20,7 +20,8 @@ def training_params(**kwargs):
         'batch_pool': None,
         'neuron_idxs': None,
         'mask_Ts': None,
-        'n_mc': 32
+        'n_mc': 32,
+        'prior_m': None
     }
 
     for key, value in kwargs.items():
@@ -44,6 +45,7 @@ def train_model(mod, data, params):
                                       print_every=params['print_every'],
                                       stop=params['callback'],
                                       neuron_idxs=params['neuron_idxs'],
-                                      mask_Ts=params['mask_Ts']),
+                                      mask_Ts=params['mask_Ts'],
+                                     prior_m=params['prior_m']),
 
     return trained_mod

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -238,9 +238,9 @@ class Exp(QuadExp):
         """
         scale_sqr, ell = self.prms
         if self.ard:
-            ell = ell[:, :, None]
+            ell = ell[:, :, None] #(n x d x 1) / (1 x d x 1)
         else:
-            ell = ell[:, None, None]
+            ell = ell[:, None, None] #(n x 1 x 1)
         distance = self.distance(x, y, ell=ell)  # dims (... n x mx x my)
 
         # NOTE: distance means squared distance ||x-y||^2 ?

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -52,7 +52,7 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
             _scale_sqr = torch.tensor(scale,
                                       dtype=torch.get_default_dtype()).square()
         elif Y is not None:
-            _scale_sqr = torch.tensor(np.mean(Y**2, axis=(0, -1)))
+            _scale_sqr = torch.tensor(1*np.mean(Y**2, axis=(0, -1)))
         else:
             _scale_sqr = torch.ones(n,)
 

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -238,9 +238,9 @@ class Exp(QuadExp):
         """
         scale_sqr, ell = self.prms
         if self.ard:
-            ell = ell[:, :, None] #(n x d x 1) / (1 x d x 1)
+            ell = ell[:, :, None]  #(n x d x 1) / (1 x d x 1)
         else:
-            ell = ell[:, None, None] #(n x 1 x 1)
+            ell = ell[:, None, None]  #(n x 1 x 1)
         distance = self.distance(x, y, ell=ell)  # dims (... n x mx x my)
 
         # NOTE: distance means squared distance ||x-y||^2 ?

--- a/mgplvm/kernels/stationary.py
+++ b/mgplvm/kernels/stationary.py
@@ -52,7 +52,7 @@ class Stationary(Kernel, metaclass=abc.ABCMeta):
             _scale_sqr = torch.tensor(scale,
                                       dtype=torch.get_default_dtype()).square()
         elif Y is not None:
-            _scale_sqr = torch.tensor(1*np.mean(Y**2, axis=(0, -1)))
+            _scale_sqr = torch.tensor(1 * np.mean(Y**2, axis=(0, -1)))
         else:
             _scale_sqr = torch.ones(n,)
 

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -180,7 +180,7 @@ class Gaussian(Likelihood):
     @property
     def msg(self):
         sig = np.mean(self.sigma.data.cpu().numpy())
-        return (' lik_sig {:.3f} |').format(sig)
+        return (' lik_sig {:.3f} |').format(sig.astype(float))
 
 
 class Poisson(Likelihood):
@@ -451,4 +451,4 @@ class NegativeBinomial(Likelihood):
     @property
     def msg(self):
         total_count = np.mean(self.prms[0].data.cpu().numpy())
-        return (' lik_count {:.3f} |').format(total_count)
+        return (' lik_count {:.3f} |').format(total_count.astype(float))

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -33,7 +33,6 @@ def FA_init(Y, d: Optional[int] = None):
     Y = Y.transpose(0, 2, 1).reshape(n_samples * m, n)
     mudata = pca.fit_transform(Y)  #m*n_samples x d
     sigmas = 1.5 * np.sqrt(pca.noise_variance_)
-    print(sigmas)
     return torch.tensor(sigmas, dtype=torch.get_default_dtype())
 
 

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -62,7 +62,7 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
     @abc.abstractstaticmethod
     def dist_mean(self, x: Tensor):
         pass
-    
+
     @property
     @abc.abstractmethod
     def msg(self):
@@ -176,7 +176,7 @@ class Gaussian(Likelihood):
 
         #(n_mc x n_samples x n)
         return ve1 + ve2 + ve3.sum(-1) + ve4.sum(-1)
-    
+
     @property
     def msg(self):
         sig = np.mean(self.sigma.data.cpu().numpy())
@@ -303,11 +303,10 @@ class Poisson(Likelihood):
             lp = self.log_prob(locs, y)
             return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-1)
             #return torch.sum(1 / np.sqrt(np.pi) * lp * ws)
-            
+
     @property
     def msg(self):
         return " "
-
 
 
 class NegativeBinomial(Likelihood):
@@ -448,9 +447,8 @@ class NegativeBinomial(Likelihood):
 
         #print(lp.shape, ws.shape, (lp * ws).shape)
         return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-1)
-    
+
     @property
     def msg(self):
         total_count = np.mean(self.prms[0].data.cpu().numpy())
         return (' lik_count {:.3f} |').format(total_count)
-

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -179,8 +179,8 @@ class Gaussian(Likelihood):
 
     @property
     def msg(self):
-        sig = np.mean(self.sigma.data.cpu().numpy())
-        return (' lik_sig {:.3f} |').format(sig.astype(float))
+        sig = torch.mean(self.sigma).item()
+        return (' lik_sig {:.3f} |').format(sig)
 
 
 class Poisson(Likelihood):
@@ -450,5 +450,5 @@ class NegativeBinomial(Likelihood):
 
     @property
     def msg(self):
-        total_count = np.mean(self.prms[0].data.cpu().numpy())
-        return (' lik_count {:.3f} |').format(total_count.astype(float))
+        total_count = torch.mean(self.prms[0]).item()
+        return (' lik_count {:.3f} |').format(total_count)

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -121,7 +121,7 @@ class S3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: Optional[None] = None) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Optional[Tensor] = None) -> Tensor:
         # distance: 2 - 2 (x dot y)
         
         if ell is None:

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -123,7 +123,11 @@ class S3(Manifold):
     @staticmethod
     def distance(x: Tensor, y: Tensor, ell: Optional[None] = None) -> Tensor:
         # distance: 2 - 2 (x dot y)
+        
+        if ell is None:
+            ell = torch.ones(1, 1, 1)
+        
         z = x.transpose(-1, -2).matmul(y)
-        res = 2 * (1 - z)
+        res = 2 * (1 - z) / ell**2
         res.clamp_min_(0)
         return res

--- a/mgplvm/manifolds/s3.py
+++ b/mgplvm/manifolds/s3.py
@@ -123,10 +123,10 @@ class S3(Manifold):
     @staticmethod
     def distance(x: Tensor, y: Tensor, ell: Optional[Tensor] = None) -> Tensor:
         # distance: 2 - 2 (x dot y)
-        
+
         if ell is None:
             ell = torch.ones(1, 1, 1)
-        
+
         z = x.transpose(-1, -2).matmul(y)
         res = 2 * (1 - z) / ell**2
         res.clamp_min_(0)

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -147,7 +147,7 @@ class So3(Manifold):
         return lp
 
     @staticmethod
-    def distance(x: Tensor, y: Tensor, ell: Optional[None] = None) -> Tensor:
+    def distance(x: Tensor, y: Tensor, ell: Optional[Tensor] = None) -> Tensor:
         """x, y: (..., n x d x m)"""
         # distance: 4 - 4 (x dot y)^2
         

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -150,11 +150,11 @@ class So3(Manifold):
     def distance(x: Tensor, y: Tensor, ell: Optional[Tensor] = None) -> Tensor:
         """x, y: (..., n x d x m)"""
         # distance: 4 - 4 (x dot y)^2
-        
+
         if ell is None:
             ell = torch.ones(1, 1, 1)
-        
-        z = x.transpose(-1, -2).matmul(y) # (..., n, m, m)
+
+        z = x.transpose(-1, -2).matmul(y)  # (..., n, m, m)
         res = 4 * (1 - z.square()) / ell**2
         res.clamp_min_(0)
         return res

--- a/mgplvm/manifolds/so3.py
+++ b/mgplvm/manifolds/so3.py
@@ -148,8 +148,13 @@ class So3(Manifold):
 
     @staticmethod
     def distance(x: Tensor, y: Tensor, ell: Optional[None] = None) -> Tensor:
+        """x, y: (..., n x d x m)"""
         # distance: 4 - 4 (x dot y)^2
-        z = x.transpose(-1, -2).matmul(y)
-        res = 4 * (1 - z.square())
+        
+        if ell is None:
+            ell = torch.ones(1, 1, 1)
+        
+        z = x.transpose(-1, -2).matmul(y) # (..., n, m, m)
+        res = 4 * (1 - z.square()) / ell**2
         res.clamp_min_(0)
         return res

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -119,7 +119,7 @@ class SvgpBase(Module, metaclass=abc.ABCMeta):
              y: Tensor,
              x: Tensor,
              sample_idxs: Optional[List[int]] = None,
-            m: Optional[int] = None) -> Tuple[Tensor, Tensor]:
+             m: Optional[int] = None) -> Tuple[Tensor, Tensor]:
         """
         Parameters
         ----------

--- a/mgplvm/models/svgplvm.py
+++ b/mgplvm/models/svgplvm.py
@@ -80,7 +80,7 @@ class SvgpLvm(nn.Module):
              batch_idxs=None,
              sample_idxs=None,
              neuron_idxs=None,
-            m = None):
+             m=None):
         """
         Parameters
         ----------
@@ -136,8 +136,10 @@ class SvgpLvm(nn.Module):
         # note that [ svgp.elbo ] recognizes inputs of dims (n_mc x d x m)
         # and so we need to permute [ g ] to have the right dimensions
         #(n_mc x n), (1 x n)
-        svgp_lik, svgp_kl = self.svgp.elbo(data, g.transpose(-1, -2),
-                                           sample_idxs, m = m)
+        svgp_lik, svgp_kl = self.svgp.elbo(data,
+                                           g.transpose(-1, -2),
+                                           sample_idxs,
+                                           m=m)
         if neuron_idxs is not None:
             svgp_lik = svgp_lik[..., neuron_idxs]
             svgp_kl = svgp_kl[..., neuron_idxs]
@@ -160,7 +162,7 @@ class SvgpLvm(nn.Module):
                 batch_idxs=None,
                 sample_idxs=None,
                 neuron_idxs=None,
-               m=None):
+                m=None):
         """
         Parameters
         ----------
@@ -199,7 +201,7 @@ class SvgpLvm(nn.Module):
                             batch_idxs=batch_idxs,
                             sample_idxs=sample_idxs,
                             neuron_idxs=neuron_idxs,
-                           m=m)
+                            m=m)
         #sum over neurons and mean over  MC samples
         lik = lik.sum(-1).mean()
         kl = kl.mean()
@@ -230,7 +232,7 @@ class SvgpLvm(nn.Module):
         """
 
         #(n_mc, n), (n_mc)
-        svgp_elbo, kl = self.elbo(data, n_mc, kmax=kmax,m=m)
+        svgp_elbo, kl = self.elbo(data, n_mc, kmax=kmax, m=m)
         svgp_elbo = svgp_elbo.sum(-1)  #(n_mc)
         LLs = svgp_elbo - kl  # LL for each batch (n_mc)
         assert (LLs.shape == torch.Size([n_mc]))

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -62,7 +62,9 @@ def print_progress(model,
                '| |mu| {:.3f} | sig {:.3f} |').format(i, svgp_elbo_val / Z,
                                                       kl_val / Z, loss_val / Z,
                                                       mu_mag, sig)
-        print(msg + model.kernel.msg + model.lprior.msg + model.svgp.likelihood.msg, end="\r")
+        print(msg + model.kernel.msg + model.lprior.msg +
+              model.svgp.likelihood.msg,
+              end="\r")
 
 
 def fit(dataset: Union[Tensor, DataLoader],
@@ -76,7 +78,7 @@ def fit(dataset: Union[Tensor, DataLoader],
         print_every: int = 50,
         mask_Ts=None,
         neuron_idxs: Optional[List[int]] = None,
-        prior_m = None):
+        prior_m=None):
     '''
     Parameters
     ----------
@@ -133,7 +135,7 @@ def fit(dataset: Union[Tensor, DataLoader],
                                   batch_idxs=batch_idxs,
                                   sample_idxs=sample_idxs,
                                   neuron_idxs=neuron_idxs,
-                                 m = prior_m)
+                                  m=prior_m)
 
             loss = (-svgp_elbo) + (ramp * kl)  # -LL
             loss_vals.append(loss.item())

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -19,8 +19,6 @@ def sort_params(model, hook):
     params0 = list(
         itertools.chain.from_iterable([
             model.z.parameters(),
-            model.likelihood.parameters(),
-            model.lprior.parameters(),
             model.lat_dist.gmu_parameters(),
             [model.svgp.q_mu, model.svgp.q_sqrt],
         ]))
@@ -28,6 +26,8 @@ def sort_params(model, hook):
     params1 = list(
         itertools.chain.from_iterable([
             model.lat_dist.concentration_parameters(),
+            model.lprior.parameters(),
+            model.likelihood.parameters(),
             model.kernel.parameters()
         ]))
 
@@ -62,7 +62,7 @@ def print_progress(model,
                '| |mu| {:.3f} | sig {:.3f} |').format(i, svgp_elbo_val / Z,
                                                       kl_val / Z, loss_val / Z,
                                                       mu_mag, sig)
-        print(msg + model.kernel.msg + model.lprior.msg, end="\r")
+        print(msg + model.kernel.msg + model.lprior.msg + model.svgp.likelihood.msg, end="\r")
 
 
 def fit(dataset: Union[Tensor, DataLoader],
@@ -75,7 +75,8 @@ def fit(dataset: Union[Tensor, DataLoader],
         stop=None,
         print_every: int = 50,
         mask_Ts=None,
-        neuron_idxs: Optional[List[int]] = None):
+        neuron_idxs: Optional[List[int]] = None,
+        prior_m = None):
     '''
     Parameters
     ----------
@@ -131,7 +132,8 @@ def fit(dataset: Union[Tensor, DataLoader],
                                   n_mc,
                                   batch_idxs=batch_idxs,
                                   sample_idxs=sample_idxs,
-                                  neuron_idxs=neuron_idxs)
+                                  neuron_idxs=neuron_idxs,
+                                 m = prior_m)
 
             loss = (-svgp_elbo) + (ramp * kl)  # -LL
             loss_vals.append(loss.item())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ sphinx
 sphinx-rtd-theme
 pytest
 pytest-cov
-torch
+torch==1.7
 numpy 
 scipy
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     version='0.0.1',
     description='Pytorch implementation of mGPLVM',
     license='MIT',
-    install_requires=['numpy', 'torch>=0.4.1', 'scipy>=1.0.0', 'scikit-learn'],
+    install_requires=['numpy', 'torch==1.7', 'scipy>=1.0.0', 'scikit-learn'],
     packages=find_packages())

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -5,6 +5,7 @@ import mgplvm
 from mgplvm import kernels, rdist, models, optimisers, syndata, likelihoods
 from mgplvm.manifolds import Torus, Euclid, So3
 import matplotlib.pyplot as plt
+
 torch.set_default_dtype(torch.float64)
 if torch.cuda.is_available():
     device = torch.device("cuda")

--- a/tests/test_entropies.py
+++ b/tests/test_entropies.py
@@ -6,6 +6,7 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+
 torch.set_default_dtype(torch.float64)
 device = mgplvm.utils.get_device()
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -6,6 +6,7 @@ import mgplvm
 from mgplvm import rdist, models, optimisers, syndata, likelihoods, lpriors
 from mgplvm.manifolds import Torus, Euclid
 import sklearn.gaussian_process.kernels as sklkernels
+
 torch.set_default_dtype(torch.float64)
 
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -5,6 +5,7 @@ import mgplvm
 from mgplvm import kernels, rdist, models, optimisers, syndata, likelihoods
 from mgplvm.manifolds import Torus, Euclid, So3
 import matplotlib.pyplot as plt
+
 torch.set_default_dtype(torch.float64)
 if torch.cuda.is_available():
     device = torch.device("cuda")

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -3,6 +3,7 @@ from mgplvm import manifolds, rdist, kernels, likelihoods, lpriors, models, opti
 import numpy as np
 import torch
 from torch import optim
+
 torch.set_default_dtype(torch.float64)
 device = mgplvm.utils.get_device()
 

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch
 from torch import optim
 import mgplvm as mgp
+
 torch.set_default_dtype(torch.float64)
 device = mgp.utils.get_device()
 

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -5,6 +5,7 @@ import mgplvm
 from mgplvm import kernels, rdist, models, optimisers, syndata, likelihoods
 from mgplvm.manifolds import Torus, Euclid, So3
 import matplotlib.pyplot as plt
+
 torch.set_default_dtype(torch.float64)
 if torch.cuda.is_available():
     device = torch.device("cuda")


### PR DESCRIPTION
In this PR we do three things:

(a) we allow svgplvm.elbo() to take an optional kwarg (m = None) specifying the size of the dataset. This overrides the value of 'm' used for initialization when re-weighting the svgp likelihood and prior KL and is used when doing crossvalidation.

(b) we update the crossvalidation function to allow for predictions using the dist_mean() function implemented in #41. This is necessary when using non-Gaussian likelihoods.

(c) we add a 'msg' method to the likelihoods and print likelihood parameters during training.