### PR TITLE
Factor analysis with ARD

### DIFF
--- a/mgplvm/base.py
+++ b/mgplvm/base.py
@@ -16,17 +16,3 @@ class Module(nn.Module, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def prms(self) -> Any:
         pass
-
-
-class NoneClass(Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @property
-    def prms(self) -> Any:
-        return
-
-    @property
-    def msg(self):
-        return ''

--- a/mgplvm/models/lgplvm.py
+++ b/mgplvm/models/lgplvm.py
@@ -31,7 +31,10 @@ class Lgplvm(Gplvm):
                  lat_dist: Rdist,
                  lprior: Lprior,
                  Bayesian=True,
-                 Y=None):
+                 Y=None,
+                learn_neuron_scale = False,
+                ard = False,
+                learn_scale = None):
         """
         __init__ method for linear GPLVM with exact posteriors and Gaussian noise
         Parameters
@@ -55,7 +58,10 @@ class Lvgplvm(Gplvm):
                  lat_dist: Rdist,
                  lprior: Lprior,
                  likelihood: Likelihood,
-                 tied_samples=True):
+                 tied_samples=True,
+                learn_neuron_scale = False,
+                ard = False,
+                learn_scale = None):
         """
         __init__ method for linear GPLVM with approximate posteriors and flexible noise models
         Parameters
@@ -63,5 +69,6 @@ class Lvgplvm(Gplvm):
         """
 
         #observation model (P(Y|X))
-        obs = Bvfa(n, d, m, n_samples, likelihood, tied_samples=tied_samples)
+        obs = Bvfa(n, d, m, n_samples, likelihood, tied_samples=tied_samples, learn_neuron_scale = learn_neuron_scale, ard = ard, learn_scale = learn_scale)
+        
         super().__init__(obs, lat_dist, lprior, n, m, n_samples)

--- a/mgplvm/models/lgplvm.py
+++ b/mgplvm/models/lgplvm.py
@@ -32,9 +32,9 @@ class Lgplvm(Gplvm):
                  lprior: Lprior,
                  Bayesian=True,
                  Y=None,
-                learn_neuron_scale = False,
-                ard = False,
-                learn_scale = None):
+                 learn_neuron_scale=False,
+                 ard=False,
+                 learn_scale=None):
         """
         __init__ method for linear GPLVM with exact posteriors and Gaussian noise
         Parameters
@@ -42,7 +42,7 @@ class Lgplvm(Gplvm):
         """
 
         #observation model (P(Y|X))
-        obs = Bfa(n, d, Y=Y) if Bayesian else Fa(n, d, Y=Y)
+        obs = Bfa(n, d, Y=Y, learn_neuron_scale=learn_neuron_scale, ard=ard, learn_scale=learn_scale) if Bayesian else Fa(n, d, Y=Y)
 
         super().__init__(obs, lat_dist, lprior, n, m, n_samples)
 
@@ -59,9 +59,9 @@ class Lvgplvm(Gplvm):
                  lprior: Lprior,
                  likelihood: Likelihood,
                  tied_samples=True,
-                learn_neuron_scale = False,
-                ard = False,
-                learn_scale = None):
+                 learn_neuron_scale=False,
+                 ard=False,
+                 learn_scale=None):
         """
         __init__ method for linear GPLVM with approximate posteriors and flexible noise models
         Parameters
@@ -69,6 +69,14 @@ class Lvgplvm(Gplvm):
         """
 
         #observation model (P(Y|X))
-        obs = Bvfa(n, d, m, n_samples, likelihood, tied_samples=tied_samples, learn_neuron_scale = learn_neuron_scale, ard = ard, learn_scale = learn_scale)
-        
+        obs = Bvfa(n,
+                   d,
+                   m,
+                   n_samples,
+                   likelihood,
+                   tied_samples=tied_samples,
+                   learn_neuron_scale=learn_neuron_scale,
+                   ard=ard,
+                   learn_scale=learn_scale)
+
         super().__init__(obs, lat_dist, lprior, n, m, n_samples)

--- a/mgplvm/models/lgplvm.py
+++ b/mgplvm/models/lgplvm.py
@@ -42,7 +42,12 @@ class Lgplvm(Gplvm):
         """
 
         #observation model (P(Y|X))
-        obs = Bfa(n, d, Y=Y, learn_neuron_scale=learn_neuron_scale, ard=ard, learn_scale=learn_scale) if Bayesian else Fa(n, d, Y=Y)
+        obs = Bfa(n,
+                  d,
+                  Y=Y,
+                  learn_neuron_scale=learn_neuron_scale,
+                  ard=ard,
+                  learn_scale=learn_scale) if Bayesian else Fa(n, d, Y=Y)
 
         super().__init__(obs, lat_dist, lprior, n, m, n_samples)
 

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -311,6 +311,8 @@ class SvgpBase(GpBase):
 
 
 class Svgp(SvgpBase):
+    
+    name = "Svgp"
 
     def __init__(self,
                  kernel: Kernel,
@@ -375,3 +377,7 @@ class Svgp(SvgpBase):
     def _expand_x(self, x: Tensor) -> Tensor:
         x = x[..., None, :, :]
         return x
+    
+    @property
+    def msg(self):
+        return self.kernel.msg + self.likelihood.msg

--- a/mgplvm/models/svgp.py
+++ b/mgplvm/models/svgp.py
@@ -11,6 +11,7 @@ from typing import Tuple, List, Optional, Union
 from torch.distributions import MultivariateNormal, kl_divergence, transform_to, constraints, Normal
 from ..likelihoods import Likelihood
 from .gp_base import GpBase
+import itertools
 
 jitter: float = 1E-8
 log2pi: float = np.log(2 * np.pi)
@@ -311,7 +312,7 @@ class SvgpBase(GpBase):
 
 
 class Svgp(SvgpBase):
-    
+
     name = "Svgp"
 
     def __init__(self,
@@ -377,7 +378,18 @@ class Svgp(SvgpBase):
     def _expand_x(self, x: Tensor) -> Tensor:
         x = x[..., None, :, :]
         return x
-    
+
     @property
     def msg(self):
         return self.kernel.msg + self.likelihood.msg
+
+    def g0_parameters(self):
+        return [self.q_mu, self.q_sqrt]
+
+    def g1_parameters(self):
+        return list(
+            itertools.chain.from_iterable([
+                self.kernel.parameters(),
+                self.z.parameters(),
+                self.likelihood.parameters()
+            ]))

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -17,40 +17,37 @@ def sort_params(model, hook):
         prm.register_hook(hook)
 
 
-#     params0 = list(
-#         itertools.chain.from_iterable([
-#             model.svgp.z.parameters(),
-#             model.lat_dist.gmu_parameters(),
-#             [model.svgp.q_mu, model.svgp.q_sqrt],
-#         ]))
 
     params0 = list(
         itertools.chain.from_iterable([
             model.lat_dist.gmu_parameters(),
+            model.svgp.parameters()
         ]))
-
-    try:
-        params0 += list(
-            itertools.chain.from_iterable([
-                [model.svgp.q_mu, model.svgp.q_sqrt],
-            ]))
-    except AttributeError:
-        None
-    try:
+        
+    params1 = list(
+        itertools.chain.from_iterable([
+            model.lat_dist.concentration_parameters(),
+            model.lprior.parameters()
+        ]))
+    
+    
+    if model.svgp.name == 'Svgp':
         params0 += list(
             itertools.chain.from_iterable([
                 model.svgp.z.parameters(),
             ]))
-    except AttributeError:
-        None
-
-    params1 = list(
-        itertools.chain.from_iterable([
-            model.lat_dist.concentration_parameters(),
-            model.lprior.parameters(),
-            model.svgp.likelihood.parameters(),
-            model.svgp.kernel.parameters()
-        ]))
+        params1 += list(
+            itertools.chain.from_iterable([
+                model.svgp.likelihood.parameters(),
+                model.svgp.kernel.parameters()
+            ]))
+    
+    elif model.svgp.name == 'Bvfa':
+        params1 += list(
+            itertools.chain.from_iterable([
+                model.svgp.likelihood.parameters(),
+            ]))
+    
 
     params = [{'params': params0}, {'params': params1}]
     return params
@@ -75,9 +72,7 @@ def print_progress(model,
             i, svgp_elbo_val / Z, kl_val / Z, loss_val / Z)
 
         print(msg + model.lat_dist.msg(Y, batch_idxs, sample_idxs) +
-              model.svgp.kernel.msg + model.lprior.msg +
-              model.svgp.likelihood.msg,
-              end="\r")
+              model.svgp.msg + model.lprior.msg, end="\r")
 
 
 def fit(dataset: Union[Tensor, DataLoader],

--- a/mgplvm/optimisers/svgp.py
+++ b/mgplvm/optimisers/svgp.py
@@ -16,38 +16,17 @@ def sort_params(model, hook):
     for prm in model.lat_dist.parameters():
         prm.register_hook(hook)
 
-
-
     params0 = list(
-        itertools.chain.from_iterable([
-            model.lat_dist.gmu_parameters(),
-            model.svgp.parameters()
-        ]))
-        
+        itertools.chain.from_iterable(
+            [model.lat_dist.gmu_parameters(),
+             model.svgp.g0_parameters()]))
+
     params1 = list(
         itertools.chain.from_iterable([
             model.lat_dist.concentration_parameters(),
-            model.lprior.parameters()
+            model.lprior.parameters(),
+            model.svgp.g1_parameters()
         ]))
-    
-    
-    if model.svgp.name == 'Svgp':
-        params0 += list(
-            itertools.chain.from_iterable([
-                model.svgp.z.parameters(),
-            ]))
-        params1 += list(
-            itertools.chain.from_iterable([
-                model.svgp.likelihood.parameters(),
-                model.svgp.kernel.parameters()
-            ]))
-    
-    elif model.svgp.name == 'Bvfa':
-        params1 += list(
-            itertools.chain.from_iterable([
-                model.svgp.likelihood.parameters(),
-            ]))
-    
 
     params = [{'params': params0}, {'params': params1}]
     return params
@@ -72,7 +51,8 @@ def print_progress(model,
             i, svgp_elbo_val / Z, kl_val / Z, loss_val / Z)
 
         print(msg + model.lat_dist.msg(Y, batch_idxs, sample_idxs) +
-              model.svgp.msg + model.lprior.msg, end="\r")
+              model.svgp.msg + model.lprior.msg,
+              end="\r")
 
 
 def fit(dataset: Union[Tensor, DataLoader],

--- a/mgplvm/rdist/rGP.py
+++ b/mgplvm/rdist/rGP.py
@@ -345,7 +345,7 @@ class EP_GP(Rdist):
         mu = K_half @ nu[..., None]  #(n_samples x d x m x 1)
         #multiply diagonal scale column wise to get cholesky factor
         scale = self.scale
-        scale = scale / scale * scale.mean()
+        #scale = scale / scale * scale.mean()
         K_half_S = K_half * scale[
             ..., None, :]  # (n_samples x d x m x m) * (n_samples x d x 1 x m)
         return mu[..., 0].transpose(-1, -2), K_half_S

--- a/tests/test_bfa.py
+++ b/tests/test_bfa.py
@@ -88,7 +88,7 @@ def test_bvfa():
     ytrain = c.matmul(xtrain) + sigma * torch.randn(n_samples, n, m)
     lik = mgp.likelihoods.Gaussian(n)
 
-    model = mgp.models.Bvfa(n, d, m, n_samples, lik)
+    model = mgp.models.Bvfa(n, d, m, n_samples, lik, learn_scale = False)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=0.008)
     for k in range(1000):

--- a/tests/test_bfa.py
+++ b/tests/test_bfa.py
@@ -88,7 +88,7 @@ def test_bvfa():
     ytrain = c.matmul(xtrain) + sigma * torch.randn(n_samples, n, m)
     lik = mgp.likelihoods.Gaussian(n)
 
-    model = mgp.models.Bvfa(n, d, m, n_samples, lik, learn_scale = False)
+    model = mgp.models.Bvfa(n, d, m, n_samples, lik, learn_scale=False)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=0.008)
     for k in range(1000):


### PR DESCRIPTION
In this PR, we add scale parameters to the linear GP methods introduced in #45 and #46 .

These are equivalent to learnable prior scale over the FA weights with the options of learning a global scale parameter, a separate parameter per neuron, or a separate parameter per latent.
Learning separate parameters per latent facilitates automatic relevance determination for FA and GPFA.

Note that the scaling per neuron has not been implemented for the Bfa.predict() function yet, only for the training loop.

Additionally, we remove the NoneClass object discussed in #48 . However, instead of introducing a separate optimizer for each class, we introduce methods for the obj classes to return their parameters appropriately for interfacing with optimisers.svgp.