### PR TITLE
Overlapping batches + zero-inflated Poisson likelihood

### DIFF
--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -311,7 +311,7 @@ class Poisson(Likelihood):
     def msg(self):
         return " "
 
-    
+
 class ZIPoisson(Likelihood):
     """
     https://en.wikipedia.org/wiki/Zero-inflated_model
@@ -327,8 +327,8 @@ class ZIPoisson(Likelihood):
             d: Optional[Tensor] = None,
             fixed_c=True,
             fixed_d=False,
-            alpha: Optional[Tensor] = None, 
-            learn_alpha=True, 
+            alpha: Optional[Tensor] = None,
+            learn_alpha=True,
             n_gh_locs: Optional[int] = n_gh_locs):
         super().__init__(n, n_gh_locs)
         self.inv_link = inv_link
@@ -338,13 +338,15 @@ class ZIPoisson(Likelihood):
         self.c = nn.Parameter(data=c, requires_grad=not fixed_c)
         self.d = nn.Parameter(data=d, requires_grad=not fixed_d)
         self.n_gh_locs = n_gh_locs
-        
-        alpha = torch.zeros(n,) if alpha is None else alpha # zero inflation probability
+
+        alpha = torch.zeros(
+            n,) if alpha is None else alpha  # zero inflation probability
         self.alpha = nn.Parameter(alpha, requires_grad=learn_alpha)
 
     @property
     def prms(self):
-        return dists.transform_to(dists.constraints.interval(0., 1.))(self.alpha), self.c, self.d
+        return dists.transform_to(dists.constraints.interval(0., 1.))(
+            self.alpha), self.c, self.d
 
     def log_prob(self, lamb, y, alpha):
         #lambd: (n_mc, n_samples x n, m, n_gh)
@@ -353,10 +355,10 @@ class ZIPoisson(Likelihood):
         Y = y[None, ..., None]
         zero_Y = (Y == 0)
         alpha_ = alpha[None, None, :, None, None]
-        
-        alpha_logp = torch.log(1-alpha_) + p.log_prob(Y) # range -infty to 0
-        logp_0 = zero_Y*torch.log(alpha_ + torch.exp(alpha_logp) + 1e-12)
-        logp_rest = (~zero_Y)*alpha_logp
+
+        alpha_logp = torch.log(1 - alpha_) + p.log_prob(Y)  # range -infty to 0
+        logp_0 = zero_Y * torch.log(alpha_ + torch.exp(alpha_logp) + 1e-12)
+        logp_rest = (~zero_Y) * alpha_logp
         return logp_0 + logp_rest
 
     def dist(self, fs: Tensor):
@@ -393,8 +395,8 @@ class ZIPoisson(Likelihood):
         bern = dists.Bernoulli(probs=alpha_)
         dist = self.dist(f_samps)
         y_samps = dist.sample()
-        zero_inflates = 1-bern.sample()
-        return zero_inflates*y_samps
+        zero_inflates = 1 - bern.sample()
+        return zero_inflates * y_samps
 
     def dist_mean(self, fs: Tensor):
         """
@@ -408,8 +410,8 @@ class ZIPoisson(Likelihood):
         mean : Tensor
             means of the resulting ZIP distributions (n_mc x n_samples x n x m)
         """
-        alpha, _, _ = self.prms 
-        dist = (1-alpha)[None, None, :, None] * self.dist(fs)
+        alpha, _, _ = self.prms
+        dist = (1 - alpha)[None, None, :, None] * self.dist(fs)
         mean = dist.mean.detach()
         return mean
 
@@ -429,7 +431,7 @@ class ZIPoisson(Likelihood):
         Log likelihood : Tensor
             SVGP likelihood term per MC, neuron, sample (n_mc x n)
         """
-        alpha, c, d = self.prms     
+        alpha, c, d = self.prms
         fmu = c[..., None] * fmu + d[..., None]
         fvar = fvar * torch.square(c[..., None])
 
@@ -448,7 +450,7 @@ class ZIPoisson(Likelihood):
     @property
     def msg(self):
         return " "
-    
+
 
 class NegativeBinomial(Likelihood):
     name = "Negative binomial"

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -311,6 +311,144 @@ class Poisson(Likelihood):
     def msg(self):
         return " "
 
+    
+class ZIPoisson(Likelihood):
+    """
+    https://en.wikipedia.org/wiki/Zero-inflated_model
+    """
+    name = "Zero-inflated Poisson"
+
+    def __init__(
+            self,
+            n: int,
+            inv_link=exp_link,  #torch.exp,
+            binsize=1,
+            c: Optional[Tensor] = None,
+            d: Optional[Tensor] = None,
+            fixed_c=True,
+            fixed_d=False,
+            alpha: Optional[Tensor] = None, 
+            learn_alpha=True, 
+            n_gh_locs: Optional[int] = n_gh_locs):
+        super().__init__(n, n_gh_locs)
+        self.inv_link = inv_link
+        self.binsize = binsize
+        c = torch.ones(n,) if c is None else c
+        d = torch.zeros(n,) if d is None else d
+        self.c = nn.Parameter(data=c, requires_grad=not fixed_c)
+        self.d = nn.Parameter(data=d, requires_grad=not fixed_d)
+        self.n_gh_locs = n_gh_locs
+        
+        alpha = torch.zeros(n,) if alpha is None else alpha # zero inflation probability
+        self.alpha = nn.Parameter(alpha, requires_grad=learn_alpha)
+
+    @property
+    def prms(self):
+        return dists.transform_to(dists.constraints.interval(0., 1.))(self.alpha), self.c, self.d
+
+    def log_prob(self, lamb, y, alpha):
+        #lambd: (n_mc, n_samples x n, m, n_gh)
+        #y: (n, n_samples x m)
+        p = dists.Poisson(lamb)
+        Y = y[None, ..., None]
+        zero_Y = (Y == 0)
+        alpha_ = alpha[None, None, :, None, None]
+        
+        alpha_logp = torch.log(1-alpha_) + p.log_prob(Y) # range -infty to 0
+        logp_0 = zero_Y*torch.log(alpha_ + torch.exp(alpha_logp) + 1e-12)
+        logp_rest = (~zero_Y)*alpha_logp
+        return logp_0 + logp_rest
+
+    def dist(self, fs: Tensor):
+        """
+        Parameters
+        ----------
+        fs : Tensor
+            GP mean function values (n_mc x n_samples x n x m)
+
+        Returns
+        -------
+        dist : distribution
+            resulting Poisson distributions
+        """
+        _, c, d = self.prms
+        lambd = self.binsize * self.inv_link(c[..., None] * fs + d[..., None])
+        dist = torch.distributions.Poisson(lambd)
+        return dist
+
+    def sample(self, f_samps: Tensor):
+        """
+        Parameters
+        ----------
+        f_samps : Tensor
+            GP output samples (n_mc x n_samples x n x m)
+
+        Returns
+        -------
+        y_samps : Tensor
+            samples from the resulting Poisson distributions (n_mc x n_samples x n x m)
+        """
+        alpha, _, _ = self.prms
+        alpha_ = alpha[None, None, :, None].expand(*f_samps.shape)
+        bern = dists.Bernoulli(probs=alpha_)
+        dist = self.dist(f_samps)
+        y_samps = dist.sample()
+        zero_inflates = 1-bern.sample()
+        return zero_inflates*y_samps
+
+    def dist_mean(self, fs: Tensor):
+        """
+        Parameters
+        ----------
+        fs : Tensor
+            GP mean function values (n_mc x n_samples x n x m)
+
+        Returns
+        -------
+        mean : Tensor
+            means of the resulting ZIP distributions (n_mc x n_samples x n x m)
+        """
+        alpha, _, _ = self.prms 
+        dist = (1-alpha)[None, None, :, None] * self.dist(fs)
+        mean = dist.mean.detach()
+        return mean
+
+    def variational_expectation(self, y, fmu, fvar):
+        """
+        Parameters
+        ----------
+        y : Tensor
+            number of MC samples (n_samples x n x m)
+        fmu : Tensor
+            GP mean (n_mc x n_samples x n x m)
+        fvar : Tensor
+            GP diagonal variance (n_mc x n_samples x n x m)
+
+        Returns
+        -------
+        Log likelihood : Tensor
+            SVGP likelihood term per MC, neuron, sample (n_mc x n)
+        """
+        alpha, c, d = self.prms     
+        fmu = c[..., None] * fmu + d[..., None]
+        fvar = fvar * torch.square(c[..., None])
+
+        # use Gauss-Hermite quadrature to approximate integral
+        locs, ws = hermgauss(self.n_gh_locs)
+        ws = torch.tensor(ws, device=fmu.device)
+        locs = torch.tensor(locs, device=fvar.device)
+        fvar = fvar[..., None]  #add n_gh
+        fmu = fmu[..., None]  #add n_gh
+        locs = self.inv_link(torch.sqrt(2. * fvar) * locs +
+                             fmu) * self.binsize  #(n_mc, n, m, n_gh)
+        lp = self.log_prob(locs, y, alpha)
+        return 1 / np.sqrt(np.pi) * (lp * ws).sum(-1).sum(-1)
+        #return torch.sum(1 / np.sqrt(np.pi) * lp * ws)
+
+    @property
+    def msg(self):
+        return " "
+    
 
 class NegativeBinomial(Likelihood):
     name = "Negative binomial"

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -45,7 +45,7 @@ class Torus(Manifold):
             mudata = torch.randn(n_samples, m, d) * 0.1
             return mudata
         elif initialization in ['uniform_random']:
-            mudata = torch.rand(n_samples, m, d) * 2*np.pi
+            mudata = torch.rand(n_samples, m, d) * 2 * np.pi
             return mudata
         else:
             print('initialization not recognized')

--- a/mgplvm/manifolds/torus.py
+++ b/mgplvm/manifolds/torus.py
@@ -44,6 +44,9 @@ class Torus(Manifold):
         elif initialization in ['random', 'Random']:
             mudata = torch.randn(n_samples, m, d) * 0.1
             return mudata
+        elif initialization in ['uniform_random']:
+            mudata = torch.rand(n_samples, m, d) * 2*np.pi
+            return mudata
         else:
             print('initialization not recognized')
         return

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -33,7 +33,7 @@ class BatchDataLoader(DataLoader):
                  batch_pool=None,
                  sample_pool=None,
                  shuffle_batch=False,
-                 shuffle_sample=False, 
+                 shuffle_sample=False,
                  overlap=0):
         super(BatchDataLoader, self).__init__(data)
         m = self.m

--- a/mgplvm/optimisers/data.py
+++ b/mgplvm/optimisers/data.py
@@ -33,10 +33,12 @@ class BatchDataLoader(DataLoader):
                  batch_pool=None,
                  sample_pool=None,
                  shuffle_batch=False,
-                 shuffle_sample=False):
+                 shuffle_sample=False, 
+                 overlap=0):
         super(BatchDataLoader, self).__init__(data)
         m = self.m
         n_samples = self.n_samples
+        self.overlap = overlap
         self.shuffle_batch = shuffle_batch
         self.shuffle_sample = shuffle_sample
         self.batch_pool = list(range(m)) if batch_pool is None else batch_pool
@@ -91,7 +93,7 @@ class BatchDataLoader(DataLoader):
     def get_next(self):
         i0 = self.i
         i1 = i0 + self.sample_size
-        k0 = self.k
+        k0 = self.k - self.overlap * (self.k > 0)
         k1 = k0 + self.batch_size
         if i1 > self.sample_pool_size:
             i1 = self.sample_pool_size

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -38,7 +38,7 @@ def test_likelihood_runs():
             likelihoods.Poisson(n),
             # using the Gauss Hermite
             likelihoods.Poisson(n, inv_link=lambda x: torch.exp(x + 2)),
-            likelihoods.ZIPoisson(n), 
+            likelihoods.ZIPoisson(n),
             likelihoods.NegativeBinomial(n)
     ]:
         # specify manifold, kernel and rdist

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -38,6 +38,7 @@ def test_likelihood_runs():
             likelihoods.Poisson(n),
             # using the Gauss Hermite
             likelihoods.Poisson(n, inv_link=lambda x: torch.exp(x + 2)),
+            likelihoods.ZIPoisson(n), 
             likelihoods.NegativeBinomial(n)
     ]:
         # specify manifold, kernel and rdist


### PR DESCRIPTION
Added overlap to BatchLoader so that one can batch AR(p) processes with overlapping end points (i.e. it slices the data with p overlapping end points per batch), let me know if this is wrong. The reason is that I cannot reproduce the 50 ms binning without running out of memory if we do not batch with an AR(p) prior, or maybe I misunderstood the implementation? Let me know.

Also added Zero - inflated Poisson process, used in grid cell literature (only overdispersed counts again). I think I used the pytorch distribution constraints correctly, although let me know if I didn't. Never used them before but they seem neat.

Added ZIP to test_likelihoods.py. So from what I see, it tests the likelihood fitting on Gaussian synthetic data?