### PR TITLE
Add CG

### DIFF
--- a/mgplvm/fast_utils/__init__.py
+++ b/mgplvm/fast_utils/__init__.py
@@ -1,1 +1,2 @@
-from .toeplitz import sym_toeplitz_matmul, sym_toeplitz
+from .toeplitz import sym_toeplitz_matmul, sym_toeplitz, toeplitz_matmul, toeplitz
+from .linear_cg import linear_cg

--- a/mgplvm/fast_utils/linear_cg.py
+++ b/mgplvm/fast_utils/linear_cg.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+
+"""
+This file taken from GPytorch https://github.com/cornellius-gp/gpytorch/blob/c74b8ed8d590fcb1d79808d9ee7cde168588ef99/gpytorch/utils/linear_cg.py
+
+With this License:
+MIT License
+
+Copyright (c) 2017 Jake Gardner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+
+import warnings
+
+import torch
+
+from .. import settings
+from .deprecation import bool_compat
+from .warnings import NumericalWarning
+
+
+def _default_preconditioner(x):
+    return x.clone()
+
+
+@torch.jit.script
+def _jit_linear_cg_updates(
+    result, alpha, residual_inner_prod, eps, beta, residual, precond_residual, mul_storage, is_zero, curr_conjugate_vec
+):
+    # # Update result
+    # # result_{k} = result_{k-1} + alpha_{k} p_vec_{k-1}
+    result = torch.addcmul(result, alpha, curr_conjugate_vec, out=result)
+
+    # beta_{k} = (precon_residual{k}^T r_vec_{k}) / (precon_residual{k-1}^T r_vec_{k-1})
+    beta.resize_as_(residual_inner_prod).copy_(residual_inner_prod)
+    torch.mul(residual, precond_residual, out=mul_storage)
+    torch.sum(mul_storage, -2, keepdim=True, out=residual_inner_prod)
+
+    # Do a safe division here
+    torch.lt(beta, eps, out=is_zero)
+    beta.masked_fill_(is_zero, 1)
+    torch.div(residual_inner_prod, beta, out=beta)
+    beta.masked_fill_(is_zero, 0)
+
+    # Update curr_conjugate_vec
+    # curr_conjugate_vec_{k} = precon_residual{k} + beta_{k} curr_conjugate_vec_{k-1}
+    curr_conjugate_vec.mul_(beta).add_(precond_residual)
+
+
+@torch.jit.script
+def _jit_linear_cg_updates_no_precond(
+    mvms,
+    result,
+    has_converged,
+    alpha,
+    residual_inner_prod,
+    eps,
+    beta,
+    residual,
+    precond_residual,
+    mul_storage,
+    is_zero,
+    curr_conjugate_vec,
+):
+    torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
+    torch.sum(mul_storage, dim=-2, keepdim=True, out=alpha)
+
+    # Do a safe division here
+    torch.lt(alpha, eps, out=is_zero)
+    alpha.masked_fill_(is_zero, 1)
+    torch.div(residual_inner_prod, alpha, out=alpha)
+    alpha.masked_fill_(is_zero, 0)
+
+    # We'll cancel out any updates by setting alpha=0 for any vector that has already converged
+    alpha.masked_fill_(has_converged, 0)
+
+    # Update residual
+    # residual_{k} = residual_{k-1} - alpha_{k} mat p_vec_{k-1}
+    torch.addcmul(residual, -alpha, mvms, out=residual)
+
+    # Update precond_residual
+    # precon_residual{k} = M^-1 residual_{k}
+    precond_residual = residual.clone()
+
+    _jit_linear_cg_updates(
+        result,
+        alpha,
+        residual_inner_prod,
+        eps,
+        beta,
+        residual,
+        precond_residual,
+        mul_storage,
+        is_zero,
+        curr_conjugate_vec,
+    )
+
+
+def linear_cg(
+    matmul_closure,
+    rhs,
+    n_tridiag=0,
+    tolerance=None,
+    eps=1e-10,
+    stop_updating_after=1e-10,
+    max_iter=None,
+    max_tridiag_iter=None,
+    initial_guess=None,
+    preconditioner=None,
+):
+    """
+    Implements the linear conjugate gradients method for (approximately) solving systems of the form
+
+        lhs result = rhs
+
+    for positive definite and symmetric matrices.
+
+    Args:
+      - matmul_closure - a function which performs a left matrix multiplication with lhs_mat
+      - rhs - the right-hand side of the equation
+      - n_tridiag - returns a tridiagonalization of the first n_tridiag columns of rhs
+      - tolerance - stop the solve when the max residual is less than this
+      - eps - noise to add to prevent division by zero
+      - stop_updating_after - will stop updating a vector after this residual norm is reached
+      - max_iter - the maximum number of CG iterations
+      - max_tridiag_iter - the maximum size of the tridiagonalization matrix
+      - initial_guess - an initial guess at the solution `result`
+      - precondition_closure - a functions which left-preconditions a supplied vector
+
+    Returns:
+      result - a solution to the system (if n_tridiag is 0)
+      result, tridiags - a solution to the system, and corresponding tridiagonal matrices (if n_tridiag > 0)
+    """
+    # Unsqueeze, if necesasry
+    is_vector = rhs.ndimension() == 1
+    if is_vector:
+        rhs = rhs.unsqueeze(-1)
+
+    # Some default arguments
+    if max_iter is None:
+        max_iter = settings.max_cg_iterations.value()
+    if max_tridiag_iter is None:
+        max_tridiag_iter = settings.max_lanczos_quadrature_iterations.value()
+    if initial_guess is None:
+        initial_guess = torch.zeros_like(rhs)
+    if tolerance is None:
+        if settings._use_eval_tolerance.on():
+            tolerance = settings.eval_cg_tolerance.value()
+        else:
+            tolerance = settings.cg_tolerance.value()
+    if preconditioner is None:
+        preconditioner = _default_preconditioner
+        precond = False
+    else:
+        precond = True
+
+    # If we are running m CG iterations, we obviously can't get more than m Lanczos coefficients
+    if max_tridiag_iter > max_iter:
+        raise RuntimeError("Getting a tridiagonalization larger than the number of CG iterations run is not possible!")
+
+    # Check matmul_closure object
+    if torch.is_tensor(matmul_closure):
+        matmul_closure = matmul_closure.matmul
+    elif not callable(matmul_closure):
+        raise RuntimeError("matmul_closure must be a tensor, or a callable object!")
+
+    # Get some constants
+    num_rows = rhs.size(-2)
+    n_iter = min(max_iter, num_rows) if settings.terminate_cg_by_size.on() else max_iter
+    n_tridiag_iter = min(max_tridiag_iter, num_rows)
+    eps = torch.tensor(eps, dtype=rhs.dtype, device=rhs.device)
+
+    # Get the norm of the rhs - used for convergence checks
+    # Here we're going to make almost-zero norms actually be 1 (so we don't get divide-by-zero issues)
+    # But we'll store which norms were actually close to zero
+    rhs_norm = rhs.norm(2, dim=-2, keepdim=True)
+    rhs_is_zero = rhs_norm.lt(eps)
+    rhs_norm = rhs_norm.masked_fill_(rhs_is_zero, 1)
+
+    # Let's normalize. We'll un-normalize afterwards
+    rhs = rhs.div(rhs_norm)
+
+    # residual: residual_{0} = b_vec - lhs x_{0}
+    residual = rhs - matmul_closure(initial_guess)
+    batch_shape = residual.shape[:-2]
+
+    # result <- x_{0}
+    result = initial_guess.expand_as(residual).contiguous()
+
+    # Maybe log
+    if settings.verbose_linalg.on():
+        settings.verbose_linalg.logger.debug(
+            f"Running CG on a {rhs.shape} RHS for {n_iter} iterations (tol={tolerance}). Output: {result.shape}."
+        )
+
+    # Check for NaNs
+    if not torch.equal(residual, residual):
+        raise RuntimeError("NaNs encountered when trying to perform matrix-vector multiplication")
+
+    # Sometime we're lucky and the preconditioner solves the system right away
+    # Check for convergence
+    residual_norm = residual.norm(2, dim=-2, keepdim=True)
+    has_converged = torch.lt(residual_norm, stop_updating_after)
+
+    if has_converged.all() and not n_tridiag:
+        n_iter = 0  # Skip the iteration!
+
+    # Otherwise, let's define precond_residual and curr_conjugate_vec
+    else:
+        # precon_residual{0} = M^-1 residual_{0}
+        precond_residual = preconditioner(residual)
+        curr_conjugate_vec = precond_residual
+        residual_inner_prod = precond_residual.mul(residual).sum(-2, keepdim=True)
+
+        # Define storage matrices
+        mul_storage = torch.empty_like(residual)
+        alpha = torch.empty(*batch_shape, 1, rhs.size(-1), dtype=residual.dtype, device=residual.device)
+        beta = torch.empty_like(alpha)
+        is_zero = torch.empty(*batch_shape, 1, rhs.size(-1), dtype=bool_compat, device=residual.device)
+
+    # Define tridiagonal matrices, if applicable
+    if n_tridiag:
+        t_mat = torch.zeros(
+            n_tridiag_iter, n_tridiag_iter, *batch_shape, n_tridiag, dtype=alpha.dtype, device=alpha.device
+        )
+        alpha_tridiag_is_zero = torch.empty(*batch_shape, n_tridiag, dtype=bool_compat, device=t_mat.device)
+        alpha_reciprocal = torch.empty(*batch_shape, n_tridiag, dtype=t_mat.dtype, device=t_mat.device)
+        prev_alpha_reciprocal = torch.empty_like(alpha_reciprocal)
+        prev_beta = torch.empty_like(alpha_reciprocal)
+
+    update_tridiag = True
+    last_tridiag_iter = 0
+
+    # It's conceivable we reach the tolerance on the last iteration, so can't just check iteration number.
+    tolerance_reached = False
+
+    # Start the iteration
+    for k in range(n_iter):
+        # Get next alpha
+        # alpha_{k} = (residual_{k-1}^T precon_residual{k-1}) / (p_vec_{k-1}^T mat p_vec_{k-1})
+        mvms = matmul_closure(curr_conjugate_vec)
+        if precond:
+            torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
+            torch.sum(mul_storage, -2, keepdim=True, out=alpha)
+
+            # Do a safe division here
+            torch.lt(alpha, eps, out=is_zero)
+            alpha.masked_fill_(is_zero, 1)
+            torch.div(residual_inner_prod, alpha, out=alpha)
+            alpha.masked_fill_(is_zero, 0)
+
+            # We'll cancel out any updates by setting alpha=0 for any vector that has already converged
+            alpha.masked_fill_(has_converged, 0)
+
+            # Update residual
+            # residual_{k} = residual_{k-1} - alpha_{k} mat p_vec_{k-1}
+            residual = torch.addcmul(residual, alpha, mvms, value=-1, out=residual)
+
+            # Update precond_residual
+            # precon_residual{k} = M^-1 residual_{k}
+            precond_residual = preconditioner(residual)
+
+            _jit_linear_cg_updates(
+                result,
+                alpha,
+                residual_inner_prod,
+                eps,
+                beta,
+                residual,
+                precond_residual,
+                mul_storage,
+                is_zero,
+                curr_conjugate_vec,
+            )
+        else:
+            _jit_linear_cg_updates_no_precond(
+                mvms,
+                result,
+                has_converged,
+                alpha,
+                residual_inner_prod,
+                eps,
+                beta,
+                residual,
+                precond_residual,
+                mul_storage,
+                is_zero,
+                curr_conjugate_vec,
+            )
+
+        torch.norm(residual, 2, dim=-2, keepdim=True, out=residual_norm)
+        residual_norm.masked_fill_(rhs_is_zero, 0)
+        torch.lt(residual_norm, stop_updating_after, out=has_converged)
+
+        if k >= 10 and bool(residual_norm.mean() < tolerance) and not (n_tridiag and k < n_tridiag_iter):
+            tolerance_reached = True
+            break
+
+        # Update tridiagonal matrices, if applicable
+        if n_tridiag and k < n_tridiag_iter and update_tridiag:
+            alpha_tridiag = alpha.squeeze_(-2).narrow(-1, 0, n_tridiag)
+            beta_tridiag = beta.squeeze_(-2).narrow(-1, 0, n_tridiag)
+            torch.eq(alpha_tridiag, 0, out=alpha_tridiag_is_zero)
+            alpha_tridiag.masked_fill_(alpha_tridiag_is_zero, 1)
+            torch.reciprocal(alpha_tridiag, out=alpha_reciprocal)
+            alpha_tridiag.masked_fill_(alpha_tridiag_is_zero, 0)
+
+            if k == 0:
+                t_mat[k, k].copy_(alpha_reciprocal)
+            else:
+                torch.addcmul(alpha_reciprocal, prev_beta, prev_alpha_reciprocal, out=t_mat[k, k])
+                torch.mul(prev_beta.sqrt_(), prev_alpha_reciprocal, out=t_mat[k, k - 1])
+                t_mat[k - 1, k].copy_(t_mat[k, k - 1])
+
+                if t_mat[k - 1, k].max() < 1e-6:
+                    update_tridiag = False
+
+            last_tridiag_iter = k
+
+            prev_alpha_reciprocal.copy_(alpha_reciprocal)
+            prev_beta.copy_(beta_tridiag)
+
+    # Un-normalize
+    result = result.mul(rhs_norm)
+
+    if not tolerance_reached and n_iter > 0:
+        warnings.warn(
+            "CG terminated in {} iterations with average residual norm {}"
+            " which is larger than the tolerance of {} specified by"
+            " gpytorch.settings.cg_tolerance."
+            " If performance is affected, consider raising the maximum number of CG iterations by running code in"
+            " a gpytorch.settings.max_cg_iterations(value) context.".format(k + 1, residual_norm.mean(), tolerance),
+            NumericalWarning,
+        )
+
+    if is_vector:
+        result = result.squeeze(-1)
+
+    if n_tridiag:
+        t_mat = t_mat[: last_tridiag_iter + 1, : last_tridiag_iter + 1]
+        return result, t_mat.permute(-1, *range(2, 2 + len(batch_shape)), 0, 1).contiguous()
+    else:
+        return result

--- a/mgplvm/fast_utils/linear_cg.py
+++ b/mgplvm/fast_utils/linear_cg.py
@@ -233,7 +233,7 @@ def linear_cg(
         is_zero = torch.empty(*batch_shape,
                               1,
                               rhs.size(-1),
-                              dtype=bool,
+                              dtype=torch.bool,
                               device=residual.device)
 
     # Define tridiagonal matrices, if applicable
@@ -246,7 +246,7 @@ def linear_cg(
                             device=alpha.device)
         alpha_tridiag_is_zero = torch.empty(*batch_shape,
                                             n_tridiag,
-                                            dtype=bool,
+                                            dtype=torch.bool,
                                             device=t_mat.device)
         alpha_reciprocal = torch.empty(*batch_shape,
                                        n_tridiag,

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -361,12 +361,14 @@ class ZIPoisson(Likelihood):
         #y: (n, n_samples x m)
         p = dists.Poisson(lamb)
         Y = y[None, ..., None]
-        zero_Y = (Y == 0) # where counts are 0
+        zero_Y = (Y == 0)  # where counts are 0
         alpha_ = alpha[None, None, :, None, None]
 
         alpha_logp = torch.log(1 - alpha_) + p.log_prob(Y)  # range -infty to 0
-        logp_0 = zero_Y * torch.log(alpha_ + torch.exp(alpha_logp) + 1e-12) # log probability of N=0 counts, stabilize with 1e-12
-        logp_rest = (~zero_Y) * alpha_logp # log probability of N>0 counts
+        logp_0 = zero_Y * torch.log(
+            alpha_ + torch.exp(alpha_logp) +
+            1e-12)  # log probability of N=0 counts, stabilize with 1e-12
+        logp_rest = (~zero_Y) * alpha_logp  # log probability of N>0 counts
         return logp_0 + logp_rest
 
     def dist(self, fs: Tensor):
@@ -400,10 +402,12 @@ class ZIPoisson(Likelihood):
         """
         alpha, _, _ = self.prms
         alpha_ = alpha[None, None, :, None].expand(*f_samps.shape)
-        bern = dists.Bernoulli(probs=alpha_) # Bernoulli with p=alpha for additional zeros
+        bern = dists.Bernoulli(
+            probs=alpha_)  # Bernoulli with p=alpha for additional zeros
         dist = self.dist(f_samps)
         y_samps = dist.sample()
-        zero_inflates = 1 - bern.sample() # locations additional zeros to Poisson
+        zero_inflates = 1 - bern.sample(
+        )  # locations additional zeros to Poisson
         return zero_inflates * y_samps
 
     def dist_mean(self, fs: Tensor):

--- a/tests/fast_utils/test_linear_cg.py
+++ b/tests/fast_utils/test_linear_cg.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Taken from GPytorch https://github.com/cornellius-gp/gpytorch/blob/2e55ec6cf6bd70dc96db76d88689dd743fd42ade/test/utils/test_linear_cg.py
+
+With this License:
+MIT License
+
+Copyright (c) 2017 Jake Gardner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import os
+import random
+
+import torch
+
+from mgplvm.fast_utils.linear_cg import linear_cg
+
+
+class TestLinearCG():
+
+    def setup_method(self, method):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv(
+                "UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(0)
+            random.seed(0)
+
+    def teardown_method(self, method):
+        if hasattr(self, "rng_state"):
+            torch.set_rng_state(self.rng_state)
+
+    def test_cg(self):
+        size = 100
+        matrix = torch.randn(size, size, dtype=torch.float64)
+        matrix = matrix.matmul(matrix.transpose(-1, -2))
+        matrix.div_(matrix.norm())
+        matrix.add_(torch.eye(matrix.size(-1), dtype=torch.float64).mul_(1e-1))
+
+        rhs = torch.randn(size, 50, dtype=torch.float64)
+        solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size)
+
+        # Check cg
+        matrix_chol = matrix.cholesky()
+        actual = torch.cholesky_solve(rhs, matrix_chol)
+        assert (torch.allclose(solves, actual, atol=1e-3, rtol=1e-4))
+
+    def test_cg_with_tridiag(self):
+        size = 10
+        matrix = torch.randn(size, size, dtype=torch.float64)
+        matrix = matrix.matmul(matrix.transpose(-1, -2))
+        matrix.div_(matrix.norm())
+        matrix.add_(torch.eye(matrix.size(-1), dtype=torch.float64).mul_(1e-1))
+
+        rhs = torch.randn(size, 50, dtype=torch.float64)
+        solves, t_mats = linear_cg(matrix.matmul,
+                                   rhs=rhs,
+                                   n_tridiag=5,
+                                   max_tridiag_iter=10,
+                                   max_iter=size,
+                                   tolerance=0,
+                                   eps=1e-15)
+
+        # Check cg
+        matrix_chol = matrix.cholesky()
+        actual = torch.cholesky_solve(rhs, matrix_chol)
+        assert (torch.allclose(solves, actual, atol=1e-3, rtol=1e-4))
+
+        # Check tridiag
+        eigs = matrix.symeig()[0]
+        for i in range(5):
+            approx_eigs = t_mats[i].symeig()[0]
+            assert (torch.allclose(eigs, approx_eigs, atol=1e-3, rtol=1e-4))
+
+    def test_batch_cg(self):
+        batch = 5
+        size = 100
+        matrix = torch.randn(batch, size, size, dtype=torch.float64)
+        matrix = matrix.matmul(matrix.transpose(-1, -2))
+        matrix.div_(matrix.norm())
+        matrix.add_(torch.eye(matrix.size(-1), dtype=torch.float64).mul_(1e-1))
+
+        rhs = torch.randn(batch, size, 50, dtype=torch.float64)
+        solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size)
+
+        # Check cg
+        matrix_chol = torch.cholesky(matrix)
+        actual = torch.cholesky_solve(rhs, matrix_chol)
+        assert (torch.allclose(solves, actual, atol=1e-3, rtol=1e-4))
+
+    def test_batch_cg_with_tridiag(self):
+        batch = 5
+        size = 10
+        matrix = torch.randn(batch, size, size, dtype=torch.float64)
+        matrix = matrix.matmul(matrix.transpose(-1, -2))
+        matrix.div_(matrix.norm())
+        matrix.add_(torch.eye(matrix.size(-1), dtype=torch.float64).mul_(1e-1))
+
+        rhs = torch.randn(batch, size, 10, dtype=torch.float64)
+        solves, t_mats = linear_cg(matrix.matmul,
+                                   rhs=rhs,
+                                   n_tridiag=8,
+                                   max_iter=size,
+                                   max_tridiag_iter=10,
+                                   tolerance=0,
+                                   eps=1e-30)
+
+        # Check cg
+        matrix_chol = torch.cholesky(matrix)
+        actual = torch.cholesky_solve(rhs, matrix_chol)
+        assert (torch.allclose(solves, actual, atol=1e-3, rtol=1e-4))
+
+        # Check tridiag
+        for i in range(5):
+            eigs = matrix[i].symeig()[0]
+            for j in range(8):
+                approx_eigs = t_mats[j, i].symeig()[0]
+                assert (torch.allclose(eigs, approx_eigs, atol=1e-3, rtol=1e-4))
+
+
+if __name__ == "__main__":
+    tests = TestLinearCG()
+    tests.test_batch_cg()
+    tests.test_linear_cg()
+    tests.test_cg_with_tridiag()
+    tests.test_batch_cg_with_tridiag()
+    tests.test_cg()

--- a/tests/fast_utils/test_toeplitz.py
+++ b/tests/fast_utils/test_toeplitz.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Taken from GPytorch with modifications https://github.com/cornellius-gp/gpytorch/blob/236304cb8420076c31d6de6a267803135055822e/test/utils/test_toeplitz.py
+
+With this License:
+MIT License
+
+Copyright (c) 2017 Jake Gardner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import torch
+import os
+
+from mgplvm.fast_utils import toeplitz, toeplitz_matmul, sym_toeplitz
+
+
+class TestToeplitz():
+
+    def setup_method(self, method):
+        if os.getenv("UNLOCK_SEED") is None or os.getenv(
+                "UNLOCK_SEED").lower() == "false":
+            self.rng_state = torch.get_rng_state()
+            torch.manual_seed(0)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(0)
+
+    def test_sym_toeplitz_constructs_tensor_from_vector(self):
+        c = torch.tensor([1, 6, 4, 5], dtype=torch.float)
+
+        res = sym_toeplitz(c)
+        actual = torch.tensor(
+            [[1, 6, 4, 5], [6, 1, 6, 4], [4, 6, 1, 6], [5, 4, 6, 1]],
+            dtype=torch.float)
+
+        assert (torch.equal(res, actual))
+
+    def test_toeplitz_matmul(self):
+        col = torch.tensor([1, 6, 4, 5], dtype=torch.float)
+        row = torch.tensor([1, 2, 1, 1], dtype=torch.float)
+        rhs_mat = torch.randn(4, 2, dtype=torch.float)
+
+        # Actual
+        lhs_mat = toeplitz(col, row)
+        actual = torch.matmul(lhs_mat, rhs_mat)
+
+        # Fast toeplitz
+        res = toeplitz_matmul(col, row, rhs_mat)
+        assert (torch.allclose(res, actual))
+
+    def test_toeplitz_matmul_batch(self):
+        cols = torch.tensor([[1, 6, 4, 5], [2, 3, 1, 0], [1, 2, 3, 1]],
+                            dtype=torch.float)
+        rows = torch.tensor([[1, 2, 1, 1], [2, 0, 0, 1], [1, 5, 1, 0]],
+                            dtype=torch.float)
+
+        rhs_mats = torch.randn(3, 4, 2, dtype=torch.float)
+
+        # Actual
+        lhs_mats = torch.zeros(3, 4, 4, dtype=torch.float)
+        for i, (col, row) in enumerate(zip(cols, rows)):
+            lhs_mats[i].copy_(toeplitz(col, row))
+        actual = torch.matmul(lhs_mats, rhs_mats)
+
+        # Fast toeplitz
+        res = toeplitz_matmul(cols, rows, rhs_mats)
+        assert (torch.allclose(res, actual))
+
+    def test_toeplitz_matmul_batchmat(self):
+        col = torch.tensor([1, 6, 4, 5], dtype=torch.float)
+        row = torch.tensor([1, 2, 1, 1], dtype=torch.float)
+        rhs_mat = torch.randn(3, 4, 2, dtype=torch.float)
+
+        # Actual
+        lhs_mat = toeplitz(col, row)
+        actual = torch.matmul(lhs_mat.unsqueeze(0), rhs_mat)
+
+        # Fast toeplitz
+        res = toeplitz_matmul(col.unsqueeze(0), row.unsqueeze(0), rhs_mat)
+        assert (torch.allclose(res, actual))
+
+
+if __name__ == "__main__":
+    tests = TestToeplitz
+    tests.test_toeplitz_matmul()
+    tests.test_toeplitz_matmul_batchmat()
+    tests.test_toeplitz_matmul_batch()
+    tests.test_sym_toeplitz_constructs_tensor_from_vector()


### PR DESCRIPTION
Add CG to allow us to later add circulant inverse, and inverse parameterizations.

This CG code is directly from GPytorch, and I haven't verified it beyond adding in their tests. 

In particular, I don't think it does the fast CG derivative stuff from Ginny's paper. That's maybe a todo for me for later (I'd like to figure it out on the GPytorch side of things too, but for now, this gets us CG quickly.