### PR TITLE
Remove a bottleneck in variational_expectation

### DIFF
--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -170,11 +170,12 @@ class Gaussian(Likelihood):
         """
         n_mc, m = fmu.shape[0], fmu.shape[-1]
         variance = self.prms
-        inv_variance = 1/variance[...,None]  #(n)
+        inv_variance = 1 / variance[..., None]  #(n)
         #print(variance.shape)
         ve1 = -0.5 * log2pi * m  #scalar
         ve2 = -0.5 * torch.log(variance) * m  #(n)
-        ve3 = -0.5 * torch.square(y - fmu) * inv_variance  #(n_mc x n_samples x n x m )
+        ve3 = -0.5 * torch.square(
+            y - fmu) * inv_variance  #(n_mc x n_samples x n x m )
         ve4 = -0.5 * fvar * inv_variance  #(n_mc x n_samples x n x m)
 
         #(n_mc x n_samples x n)

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -169,8 +169,8 @@ class Gaussian(Likelihood):
             SVGP likelihood term per MC, neuron, sample (n_mc x n_samples x n)
         """
         n_mc, m = fmu.shape[0], fmu.shape[-1]
-        variance = self.prms
-        inv_variance = 1 / variance[..., None]  #(n)
+        variance = self.prms  #(n)
+        inv_variance = 1 / variance[..., None]
         #print(variance.shape)
         ve1 = -0.5 * log2pi * m  #scalar
         ve2 = -0.5 * torch.log(variance) * m  #(n)

--- a/mgplvm/likelihoods.py
+++ b/mgplvm/likelihoods.py
@@ -169,13 +169,13 @@ class Gaussian(Likelihood):
             SVGP likelihood term per MC, neuron, sample (n_mc x n_samples x n)
         """
         n_mc, m = fmu.shape[0], fmu.shape[-1]
-        variance = self.prms  #(n)
+        variance = self.prms
+        inv_variance = 1/variance[...,None]  #(n)
         #print(variance.shape)
         ve1 = -0.5 * log2pi * m  #scalar
         ve2 = -0.5 * torch.log(variance) * m  #(n)
-        ve3 = -0.5 * torch.square(y - fmu) / variance[
-            ..., None]  #(n_mc x n_samples x n x m )
-        ve4 = -0.5 * fvar / variance[..., None]  #(n_mc x n_samples x n x m)
+        ve3 = -0.5 * torch.square(y - fmu) * inv_variance  #(n_mc x n_samples x n x m )
+        ve4 = -0.5 * fvar * inv_variance  #(n_mc x n_samples x n x m)
 
         #(n_mc x n_samples x n)
         return ve1 + ve2 + ve3.sum(-1) + ve4.sum(-1)


### PR DESCRIPTION
Gaussian variational expectation gets called a lot in the thing I profiled, before there was an extra division that also got back-propagated through. It was taking a lot of time. Now it doesn't.